### PR TITLE
added seach functionality to User Messages (email)

### DIFF
--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Requests\BaseRequest.cs" />
     <Compile Include="Requests\Extensions\DriveSpecialCollectionRequestBuilderExtensions.cs" />
     <Compile Include="Requests\Extensions\IDriveSpecialCollectionRequestBuilderExtensions.cs" />
+    <Compile Include="Requests\Extensions\IUserMessagesCollectionRequestExtensions.cs" />
     <Compile Include="Requests\Extensions\UserMessagesCollectionRequestExtensions.cs" />
     <Compile Include="Requests\IBaseRequestBuilder.cs" />
     <Compile Include="Requests\BaseRequestBuilder.cs" />

--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -58,6 +58,7 @@
     <Compile Include="Requests\BaseRequest.cs" />
     <Compile Include="Requests\Extensions\DriveSpecialCollectionRequestBuilderExtensions.cs" />
     <Compile Include="Requests\Extensions\IDriveSpecialCollectionRequestBuilderExtensions.cs" />
+    <Compile Include="Requests\Extensions\UserMessagesCollectionRequestExtensions.cs" />
     <Compile Include="Requests\IBaseRequestBuilder.cs" />
     <Compile Include="Requests\BaseRequestBuilder.cs" />
     <Compile Include="Requests\Extensions\IUserMailFoldersCollectionRequestBuilderExtensions.cs" />

--- a/src/Microsoft.Graph/Requests/Extensions/IUserMessagesCollectionRequestExtensions.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/IUserMessagesCollectionRequestExtensions.cs
@@ -4,17 +4,13 @@
 
 namespace Microsoft.Graph
 {
-    public partial class UserMessagesCollectionRequest
+    public partial interface IUserMessagesCollectionRequest
     {
         /// <summary>
         /// Adds the specified search value to the request.
         /// </summary>
         /// <param name="value">The search value.</param>
         /// <returns>The request object to send.</returns>
-        public IUserMessagesCollectionRequest Search(string value)
-        {
-            this.QueryOptions.Add(new QueryOption("$search", value));
-            return this;
-        }
+        IUserMessagesCollectionRequest Search(string value);
     }
 }

--- a/src/Microsoft.Graph/Requests/Extensions/UserMessagesCollectionRequestExtensions.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/UserMessagesCollectionRequestExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Graph
+{
+    public partial class UserMessagesCollectionRequest
+    {
+        public IUserMessagesCollectionRequest Search(string value)
+        {
+            this.QueryOptions.Add(new QueryOption("$search", value));
+            return this;
+        }
+    }
+
+    public partial interface IUserMessagesCollectionRequest
+    {
+        IUserMessagesCollectionRequest Search(string value);
+    }
+}

--- a/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
+++ b/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Models\Generated\EntityTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Requests\Extensions\DriveItemRequestBuilderExtensionsTests.cs" />
+    <Compile Include="Requests\Extensions\UserMessagesCollectionExtensionTests.cs" />
     <Compile Include="Requests\Extensions\UserRequestBuilderExtensionsTests.cs" />
     <Compile Include="Requests\Extensions\DriveSpecialCollectionRequestBuilderExtensionsTests.cs" />
     <Compile Include="Requests\Extensions\MailFolderMessagesCollectionRequestBuilderExtensionsTests.cs" />

--- a/tests/Microsoft.Graph.Test/Requests/Extensions/UserMessagesCollectionExtensionTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Extensions/UserMessagesCollectionExtensionTests.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Test.Requests.Extensions
+{
+    using System;
+
+    using Microsoft.Graph;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class UserMessagesCollectionExtensionTests : RequestTestBase
+    {
+
+        [TestMethod]
+        public void Search()
+        {
+            var expectedRequestUrl = string.Format("{0}/me/messages", this.graphBaseUrl);
+
+            var userMessagesCollectionRequest = this.graphServiceClient.Me.Messages.Request().Search("\"to:user@mail.com\"") as UserMessagesCollectionRequest;
+
+            Assert.IsNotNull(userMessagesCollectionRequest, "Unexpected request.");
+            Assert.AreEqual(new Uri(expectedRequestUrl), new Uri(userMessagesCollectionRequest.RequestUrl), "Unexpected request URL.");
+            Assert.AreEqual(1, userMessagesCollectionRequest.QueryOptions.Count, "Unexpected number of query options.");
+            Assert.AreEqual("$search", userMessagesCollectionRequest.QueryOptions[0].Name, "Unexpected query option name.");
+            Assert.AreEqual("\"to:user@mail.com\"", userMessagesCollectionRequest.QueryOptions[0].Value, "Unexpected query option value.");
+        }
+    }
+}


### PR DESCRIPTION
Resubmitting to dev branch per pr #13 

Usage would be  

``` c#
await graphClient.Me
          .Messages
          .Request()
          .Search("\"to:user@domain.com\"")
          .GetAsync();
```
