### PR TITLE
Allow passing options collection to Request method for stream requests

### DIFF
--- a/src/Microsoft.Graph/Requests/Generated/DriveItemContentRequestBuilder.cs
+++ b/src/Microsoft.Graph/Requests/Generated/DriveItemContentRequestBuilder.cs
@@ -29,10 +29,11 @@ namespace Microsoft.Graph
         /// <summary>
         /// Builds the request.
         /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        public IDriveItemContentRequest Request()
+        public IDriveItemContentRequest Request(IEnumerable<Option> options = null)
         {
-            return new DriveItemContentRequest(this.RequestUrl, this.Client, null);
+            return new DriveItemContentRequest(this.RequestUrl, this.Client, options);
         }
     }
 }

--- a/src/Microsoft.Graph/Requests/Generated/IDriveItemContentRequestBuilder.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IDriveItemContentRequestBuilder.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Graph
         /// <summary>
         /// Builds the request.
         /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        IDriveItemContentRequest Request();
+        IDriveItemContentRequest Request(IEnumerable<Option> options = null);
     }
 }

--- a/src/Microsoft.Graph/Requests/Generated/IProfilePhotoContentRequestBuilder.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IProfilePhotoContentRequestBuilder.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Graph
         /// <summary>
         /// Builds the request.
         /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        IProfilePhotoContentRequest Request();
+        IProfilePhotoContentRequest Request(IEnumerable<Option> options = null);
     }
 }

--- a/src/Microsoft.Graph/Requests/Generated/IThumbnailContentRequestBuilder.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IThumbnailContentRequestBuilder.cs
@@ -17,7 +17,8 @@ namespace Microsoft.Graph
         /// <summary>
         /// Builds the request.
         /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        IThumbnailContentRequest Request();
+        IThumbnailContentRequest Request(IEnumerable<Option> options = null);
     }
 }

--- a/src/Microsoft.Graph/Requests/Generated/ProfilePhotoContentRequestBuilder.cs
+++ b/src/Microsoft.Graph/Requests/Generated/ProfilePhotoContentRequestBuilder.cs
@@ -29,10 +29,11 @@ namespace Microsoft.Graph
         /// <summary>
         /// Builds the request.
         /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        public IProfilePhotoContentRequest Request()
+        public IProfilePhotoContentRequest Request(IEnumerable<Option> options = null)
         {
-            return new ProfilePhotoContentRequest(this.RequestUrl, this.Client, null);
+            return new ProfilePhotoContentRequest(this.RequestUrl, this.Client, options);
         }
     }
 }

--- a/src/Microsoft.Graph/Requests/Generated/ThumbnailContentRequestBuilder.cs
+++ b/src/Microsoft.Graph/Requests/Generated/ThumbnailContentRequestBuilder.cs
@@ -29,10 +29,11 @@ namespace Microsoft.Graph
         /// <summary>
         /// Builds the request.
         /// </summary>
+        /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        public IThumbnailContentRequest Request()
+        public IThumbnailContentRequest Request(IEnumerable<Option> options = null)
         {
-            return new ThumbnailContentRequest(this.RequestUrl, this.Client, null);
+            return new ThumbnailContentRequest(this.RequestUrl, this.Client, options);
         }
     }
 }


### PR DESCRIPTION
This is needed in order to add things like the nameConflictBehavior query param when building the request. Also, would allow adding custom headers, etc.

Generated from [this PR](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/34).