### PR TITLE
Schema extensions

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -116,7 +116,7 @@ Expand, Skip, Top, OrderBy, and Filter are also supported via the client library
 
 Please see [collections](/docs/collections.md) for details on collections and paging.
 
-## Use the .Net Microsoft Graph client library when the client doesn't support a feature
+## Send HTTP requests with the .Net Microsoft Graph client library
 
 Sometimes, the functionality that you want to use isn't a part of the .Net client library. In this case, you can still use the client library to make your life easier. The client library can authenticate your requests and provide you the serializers. Here's an example of using the client library to create a OneNote page and deserialize the response object. 
 
@@ -154,7 +154,12 @@ public async Task OneNoteAddPageHtml()
         OnenotePage page = graphClient.HttpProvider.Serializer.DeserializeObject<OnenotePage>(content);
     }
     else
-        throw new Exception("Error");
+        throw new ServiceException(
+            new Error
+            {
+                Code = response.StatusCode.ToString(),
+                Message = await response.Content.ReadAsStringAsync()
+            });
 }
 
 ```

--- a/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
+++ b/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
@@ -97,6 +97,7 @@
     <Compile Include="Requests\Functional\MiscTests.cs" />
     <Compile Include="Requests\Functional\SharePointTests.cs" />
     <Compile Include="Requests\Functional\OneNoteTests.cs" />
+    <Compile Include="Requests\Functional\SchemaExtensionTests.cs" />
     <Compile Include="Requests\Functional\UsersTests.cs" />
     <Compile Include="Requests\Generated\EntityWithReferenceRequestTests.cs" />
     <Compile Include="Requests\Generated\EntityReferenceRequestTests.cs" />

--- a/tests/Microsoft.Graph.Test/Requests/Functional/OneNoteTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/OneNoteTests.cs
@@ -30,8 +30,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
 
             // Get a handle to the first section.
             firstSectionID = sectionPage[0].Id;
-
-            //await Async.Task.Delay(5000);
         }
 
         public async void TestPageCleanUp()
@@ -384,10 +382,15 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     StringAssert.Contains(testPage.Title, title, "Expected: title from the posted body matches the title in the OneNotePage object. That didn't happen");
                     Assert.IsNull(testPage.Content, "Expected: content property does not contain anything. Actual: there's an unexpected object in the content property.");
 
-                    TestPageCleanUp();
+                    TestPageCleanUp(); 
                 }
                 else
-                    throw new Exception("Error");
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = response.StatusCode.ToString(),
+                            Message = await response.Content.ReadAsStringAsync()
+                        });
             }
             catch (Microsoft.Graph.ServiceException e)
             {
@@ -451,7 +454,12 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     TestPageCleanUp();
                 }
                 else
-                    throw new Exception("Error");
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = response.StatusCode.ToString(),
+                            Message = await response.Content.ReadAsStringAsync()
+                        });
             }
             catch (Microsoft.Graph.ServiceException e)
             {
@@ -536,7 +544,12 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     TestPageCleanUp();
                 }
                 else
-                    throw new Exception("Error");
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = response.StatusCode.ToString(),
+                            Message = await response.Content.ReadAsStringAsync()
+                        });
             }
             catch (Microsoft.Graph.ServiceException e)
             {
@@ -610,7 +623,12 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     Assert.AreEqual(response.StatusCode, System.Net.HttpStatusCode.NoContent, $"Expected: 204 No Content, Actual: {response.StatusCode}");
                 }
                 else
-                    throw new Exception("Error");
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = response.StatusCode.ToString(),
+                            Message = await response.Content.ReadAsStringAsync()
+                        });
             }
             catch (Microsoft.Graph.ServiceException e)
             {

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SchemaExtensionTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SchemaExtensionTests.cs
@@ -6,7 +6,7 @@ using Async = System.Threading.Tasks;
 
 namespace Microsoft.Graph.Test.Requests.Functional
 {
-    //[Ignore]
+    [Ignore]
     [TestClass]
     public class SchemaExtensionTests : GraphTestBase
     {

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SchemaExtensionTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SchemaExtensionTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using System.IO;
+using Async = System.Threading.Tasks;
+
+namespace Microsoft.Graph.Test.Requests.Functional
+{
+    [Ignore]
+    [TestClass]
+    public class SchemaExtensionTests : GraphTestBase
+    {
+        /// <summary>
+        /// Create a schema extension test 
+        /// https://developer.microsoft.com/en-us/graph/docs/api-reference/v1.0/api/schemaextension_post_schemaextensions
+        /// </summary>
+        [TestMethod]
+        public async Async.Task CreateSchemaExtension()
+        {
+            // Create a schema extension on a contact.
+            SchemaExtension extensionPayload = new SchemaExtension()
+            {
+                Description = "This extension correlates a group with a foreign database.",
+                Id = $"crmForeignKey", // Microsoft Graph will prepend 8 chars
+                Properties = new List<ExtensionSchemaProperty>()
+                {
+                    new ExtensionSchemaProperty() { Name = "fid", Type = "Integer" }
+                },
+                TargetTypes = new List<string>()
+                {
+                    "Group"
+                }
+            };
+
+            // Create the schema extension. This results in a call to Microsoft Graph.
+            SchemaExtension schemaExtension = await graphClient.SchemaExtensions.Request().AddAsync(extensionPayload);
+            Assert.IsNotNull(schemaExtension, "Expected: schemaExtension is not null; Actual: it returned null");
+            Assert.AreEqual(schemaExtension.Status, "InDevelopment", $"Expected: a new schem extension has a status as InDevelopment; Actual: {schemaExtension.Status}");
+            StringAssert.Contains(schemaExtension.Id, extensionPayload.Id, "Expected: the payload identifier is contained in the schema extension returned by the service; Actual: it is not returned");
+            Assert.IsNotNull(schemaExtension.Owner, "Expected: the owner value is set by the service; Actual: it wasn't set by the service.");
+
+            // List all of the schema extensions available to this application.
+            IGraphServiceSchemaExtensionsCollectionPage schemaExtensions = await graphClient.SchemaExtensions.Request().GetAsync();
+            Assert.IsTrue(schemaExtensions.Count > 0, "Expected: at least one schema extension; Actual: 0");
+            Assert.IsNotNull(schemaExtensions[0].Properties, "Expected: the extension properties are set; Actual: extension properties are not set.");
+            Assert.IsTrue(schemaExtensions[0].Description.Length > 0, "Expected: the description has at least one character; Actual: the description was not set");
+            Assert.IsNotNull(schemaExtensions[0].TargetTypes, "Expected: the extension targets are set; Actual: extension targets are not set.");
+            Assert.IsNotNull(schemaExtensions[0].Id, "Expected: the Id property is set; Actual: Id property is not set.");
+
+            // Get a specific schema extension.
+            SchemaExtension extensionFromGet = await graphClient.SchemaExtensions[schemaExtension.Id].Request().GetAsync();
+            Assert.IsNotNull(extensionFromGet, "Expected: returned a schema extension object; Actual: an object wasn't returned.");
+
+            // Add header so we get back a representation of the updated schema extension.
+            List<HeaderOption> headers = new List<HeaderOption>();
+            HeaderOption preferHeader = new HeaderOption("Prefer", "return=representation");
+            headers.Add(preferHeader);
+
+            // Update a specific schema extension.
+            extensionFromGet.Status = "Available";
+
+            // Potential bug: state transition from deprecated to available is not working.
+            // Potential bug here as the service is not returning the SchemaExtension on update. Must delete test until this is fixed. 5/30/2017
+            SchemaExtension extensionFromUpdate = await graphClient.SchemaExtensions[extensionFromGet.Id].Request(headers).UpdateAsync(extensionFromGet);
+            
+            // Enable or re-write test when we learn expected behavior.
+            //Assert.AreEqual(extensionFromGet.Status, extensionFromUpdate.Status, "Expected: the patch object status property matches the returned status property; Actual: they don't match.");
+
+            // Delete a specific scheam extension.
+            await graphClient.SchemaExtensions[extensionFromGet.Id].Request().DeleteAsync();
+            try
+            {
+                var deletedSchemaExtension = await graphClient.SchemaExtensions[extensionFromGet.Id].Request().GetAsync();
+                Assert.Fail("Expected: ServiceException since the schema extension ws deleted; Actual: the GET on the supposedly deleted schema extension returned successfully.");
+            }
+            catch (ServiceException e)
+            {
+                Assert.AreEqual(e.StatusCode == System.Net.HttpStatusCode.NotFound, $"Expected: {System.Net.HttpStatusCode.NotFound}; Actual: {e.StatusCode}");
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SchemaExtensionTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SchemaExtensionTests.cs
@@ -6,7 +6,7 @@ using Async = System.Threading.Tasks;
 
 namespace Microsoft.Graph.Test.Requests.Functional
 {
-    [Ignore]
+    //[Ignore]
     [TestClass]
     public class SchemaExtensionTests : GraphTestBase
     {
@@ -57,12 +57,13 @@ namespace Microsoft.Graph.Test.Requests.Functional
             headers.Add(preferHeader);
 
             // Update a specific schema extension.
-            extensionFromGet.Status = "Available";
+            extensionFromGet.Description = "This extension will be deleted";
 
             // Potential bug: state transition from deprecated to available is not working.
             // Potential bug here as the service is not returning the SchemaExtension on update. Must delete test until this is fixed. 5/30/2017
-            SchemaExtension extensionFromUpdate = await graphClient.SchemaExtensions[extensionFromGet.Id].Request(headers).UpdateAsync(extensionFromGet);
-            
+            // SchemaExtension extensionFromUpdate = await graphClient.SchemaExtensions[extensionFromGet.Id].Request(headers).UpdateAsync(extensionFromGet);
+            await graphClient.SchemaExtensions[extensionFromGet.Id].Request(headers).UpdateAsync(extensionFromGet);
+
             // Enable or re-write test when we learn expected behavior.
             //Assert.AreEqual(extensionFromGet.Status, extensionFromUpdate.Status, "Expected: the patch object status property matches the returned status property; Actual: they don't match.");
 
@@ -75,7 +76,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
             }
             catch (ServiceException e)
             {
-                Assert.AreEqual(e.StatusCode == System.Net.HttpStatusCode.NotFound, $"Expected: {System.Net.HttpStatusCode.NotFound}; Actual: {e.StatusCode}");
+                Assert.AreEqual(e.StatusCode, System.Net.HttpStatusCode.NotFound, $"Expected: {System.Net.HttpStatusCode.NotFound}; Actual: {e.StatusCode}");
             }
         }
     }

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
@@ -106,7 +106,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
             try
             {
                 // 
-                Site site = graphClient.Shares[UrlToSharingToken("https://mod810997.sharepoint.com/sites/SMBverticals")].Site.Request().GetAsync().Result;
+                Site site = await graphClient.Shares[UrlToSharingToken("https://mod810997.sharepoint.com/sites/SMBverticals")].Site.Request().GetAsync();
                 Assert.IsNotNull(site);
             }
             catch (Microsoft.Graph.ServiceException e)


### PR DESCRIPTION
Forked off of OneNote work so only review commit 2b377e4. While I've seen the test run fine, we are blocked on running the tests again with this app registration since I can't delete the existing schema extensions and we've hit the max for number of schema extensions per app. The state machine appears broken so I can't get an extension to a deletable state.