### PR TITLE
Suppress JSON.Net's instinct to parse dates as dates

### DIFF
--- a/src/Microsoft.Graph.Core/Serialization/Serializer.cs
+++ b/src/Microsoft.Graph.Core/Serialization/Serializer.cs
@@ -20,7 +20,8 @@ namespace Microsoft.Graph
                   new JsonSerializerSettings
                   {
                       ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
-                      TypeNameHandling = TypeNameHandling.None
+                      TypeNameHandling = TypeNameHandling.None,
+                      DateParseHandling = DateParseHandling.None
                   })
         {
         }


### PR DESCRIPTION
Fix for issue #180 

Json.Net (when it's parsing things as part of a JsonReader) sees strings that look like dates, and converts them to Date JTokens. This is problematic when the value of a string _is_ a date, but the field on the object is a string. It causes Dates to be converted to dates, then converted back to strings (using the CurrentLocale ).

This suppresses that default behavior.