### PR TITLE
Exposed timeout via ihttpprovider interface

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!-- Read me before you submit this issue
+
+First off, thank you for taking the time to open this issue! We do appreciate it. Please bare with us if we don't get to this right away.
+
+If this is a question about the Microsoft Graph service API, or a question about this client library, please post your question to StackOverflow with the [microsoftgraph] tag.
+
+Before you open this issue, did you:
+- Search the issues to determine whether someone already opened this issue.
+- Search StackOverflow for an answer.
+- Capture the repro and gather the information requested in the steps to reproduce your scenario.
+- Reviewed the samples under github.com/microsoftgraph. They can help for some scenarios.
+- Take a look at the functional tests in this repo. They may have an example for you. https://github.com/microsoftgraph/msgraph-sdk-dotnet/tree/dev/tests/Microsoft.Graph.Test/Requests/Functional
+
+-->
+
+Please provide the following (and please check them off the list with [x]) before submitting this issue:
+- [ ] Expected behavior. Please provide links to the specific Microsoft Graph documentation you used to determine the expected behavior. 
+- [ ] Actual behavior. Provide error codes, stack information, and a Fiddler capture of the request and response.
+- [ ] Steps to reproduce the behavior. Include IDE versions, client library versions, and any other information that might be helpful to understand your scenario.
+
+### Expected behavior
+
+
+
+
+### Actual behavior
+
+
+
+
+### Steps to reproduce the behavior
+
+
+
+

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,21 +1,21 @@
 <!-- Read me before you submit this issue
 
-First off, thank you for taking the time to open this issue! We do appreciate it. Please bare with us if we don't get to this right away.
+First off, thank you for taking the time to open this issue! We do appreciate it. Please bear with us if we don't get to this right away.
 
-If this is a question about the Microsoft Graph service API, or a question about this client library, please post your question to StackOverflow with the [microsoftgraph] tag.
+If this is a question about the Microsoft Graph service API, or a question about how to use this client library, please post your question to StackOverflow with the [microsoftgraph] tag.
 
 Before you open this issue, did you:
-- Search the issues to determine whether someone already opened this issue.
-- Search StackOverflow for an answer.
-- Capture the repro and gather the information requested in the steps to reproduce your scenario.
-- Reviewed the samples under github.com/microsoftgraph. They can help for some scenarios.
-- Take a look at the functional tests in this repo. They may have an example for you. https://github.com/microsoftgraph/msgraph-sdk-dotnet/tree/dev/tests/Microsoft.Graph.Test/Requests/Functional
+- Search the issues to determine whether someone already opened this issue?
+- Search StackOverflow for an answer?
+- Capture the repro and gather the information requested in the steps below to reproduce your scenario?
+- Review the samples under github.com/microsoftgraph? They can help for some scenarios.
+- Take a look at the functional tests in this repo? They may have an example for you. See the [functional tests](https://github.com/microsoftgraph/msgraph-sdk-dotnet/tree/dev/tests/Microsoft.Graph.Test/Requests/Functional)
 
 -->
 
 Please provide the following (and please check them off the list with [x]) before submitting this issue:
-- [ ] Expected behavior. Please provide links to the specific Microsoft Graph documentation you used to determine the expected behavior. 
-- [ ] Actual behavior. Provide error codes, stack information, and a Fiddler capture of the request and response.
+- [ ] Expected behavior. Please provide **links to the specific Microsoft Graph documentation** you used to determine the expected behavior. 
+- [ ] Actual behavior. Provide error codes, stack information, and a [Fiddler](http://www.telerik.com/fiddler) capture of the request and response.
 - [ ] Steps to reproduce the behavior. Include IDE versions, client library versions, and any other information that might be helpful to understand your scenario.
 
 ### Expected behavior

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,20 +3,23 @@
 First off, thank you for taking the time to open this issue! We do appreciate it. Please bear with us if we don't get to this right away.
 
 If this is a question about the Microsoft Graph service API, or a question about how to use this client library, please post your question to StackOverflow with the [microsoftgraph] tag.
+https://stackoverflow.com/questions/tagged/microsoft-graph
+
+This repo is for the Microsoft Graph .Net client library. Issues opened in this repo should only target this client library.
 
 Before you open this issue, did you:
 - Search the issues to determine whether someone already opened this issue?
 - Search StackOverflow for an answer?
-- Capture the repro and gather the information requested in the steps below to reproduce your scenario?
+- Capture the repro steps and gather the information requested in the steps below to reproduce your scenario?
 - Review the samples under github.com/microsoftgraph? They can help for some scenarios.
 - Take a look at the functional tests in this repo? They may have an example for you. See the [functional tests](https://github.com/microsoftgraph/msgraph-sdk-dotnet/tree/dev/tests/Microsoft.Graph.Test/Requests/Functional)
 
 -->
 
 Please provide the following (and please check them off the list with [x]) before submitting this issue:
-- [ ] Expected behavior. Please provide **links to the specific Microsoft Graph documentation** you used to determine the expected behavior. 
-- [ ] Actual behavior. Provide error codes, stack information, and a [Fiddler](http://www.telerik.com/fiddler) capture of the request and response.
-- [ ] Steps to reproduce the behavior. Include IDE versions, client library versions, and any other information that might be helpful to understand your scenario.
+- [ ] Expected behavior. Please provide **links to the specific [Microsoft Graph documentation](https://developer.microsoft.com/en-us/graph/docs/concepts/overview)** you used to determine the expected behavior. 
+- [ ] Actual behavior. Provide error codes, stack information, and a [Fiddler](http://www.telerik.com/fiddler) capture of the request and response (please remove personally identifiable information before posting).
+- [ ] Steps to reproduce the behavior. Include your code, IDE versions, client library versions, and any other information that might be helpful to understand your scenario.
 
 ### Expected behavior
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!-- Read me before you submit this pull request
+
+First off, thank you for opening this pull request! We do appreciate it.
+
+The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
+it when you open pull requests with the proposed file changesas we'll use that to help guide us in updating our template files.
+
+-->
+
+<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
+Fixes #
+
+<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
+### Changes proposed in this pull request
+-
+-
+-
+
+<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if itis not used. -->
+### Other links
+-
+-
+-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,7 +16,7 @@ Fixes #
 -
 -
 
-<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if itis not used. -->
+<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
 ### Other links
 -
 -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing to the Microsoft Graph .Net Client Library
+Thanks for considering making a contribution! Read over our guidelines and we will do our best to see your PRs merged successfully.
+
+**NOTE**: A signed a contribution license agreement is required for all contributions and is checked automatically on new pull requests. You will be asked to read and sign the agreement https://cla.microsoft.com/ after submitting a request to this repository.
+
+There are a few different recommended paths to get contributions into the released version of this library.
+
+## File issues
+The best way to get started with a contribution is to start a dialog with us. Sometimes features will be under development or out of scope for this library and it's best to check before starting work on contribution, especially for large work items.
+
+## Pull requests
+All pull requests should be submitted against the **dev** branch or a specific feature branch. The master branch is intended to represent the code released in the most-recent Nuget package.
+
+When a new package is about to be released, changes in dev will be merged into master. The package will be generated from master.
+
+Some things to note about this project:
+
+### How the library is built
+The .Net client library has a handwritten set of core files and two folders of generated models and request builders. These models and request builders are generated using the [MSGraph SDK Code Generator](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator). **Changes made to the ```Models``` and ```Requests``` folders will be overwritten** the next time the generator is run. 
+
+### How the generator works
+You can view the [README](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/blob/master/README.md) for a full run-through of its capabilities.
+
+For the purposes of the .Net client library, the generator runs through an OData-compliant metadata file published by Microsoft Graph (https://graph.microsoft.com/v1.0/$metadata) and builds up an in-memory list of models. These models are converted into C# code files using T4 templates.
+
+### When new features are added to the library
+Generation happens as part of a manual process that occurs once a significant change or set of changes has been added to the Graph. This may include:
+ - A new workload comes to v1.0 of Graph (Microsoft Teams, Batching, etc.)
+ - There is significant addition of functionality (Delta Queries, etc.)
+ 
+However, this is evaluated on a case-by-case basis. If the library is missing v1.0 Graph functionality that you wish to utilize, please [file an issue](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues).
+
+We do our best to prevent breaking changes from being introduced into the library during this process. If you find a breaking change, please file an issue and we will work to get this resolved ASAP.

--- a/src/Microsoft.Graph.Core/Requests/IHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/IHttpProvider.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Graph
         ISerializer Serializer { get; }
 
         /// <summary>
+        /// Gets or sets the timeout interval. The default value is 100 seconds.
+        /// </summary>
+        TimeSpan OverallTimeout { get; set; }
+
+        /// <summary>
         /// Sends the request.
         /// </summary>
         /// <param name="request">The <see cref="HttpRequestMessage"/> to send.</param>

--- a/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
         {
             // Get a groups collection. We'll use the first entry to add the extension. Results in a call to the service.
             IGraphServiceGroupsCollectionPage groupPage = await graphClient.Groups.Request().GetAsync();
-
+            graphClient.HttpProvider.OverallTimeout = new TimeSpan(5000000);
             // Create the extension property.
             OpenTypeExtension newExtension = new OpenTypeExtension();
             newExtension.ExtensionName = "com.contoso.trackingKey";
@@ -37,6 +37,31 @@ namespace Microsoft.Graph.Test.Requests.Functional
             catch (ServiceException e)
             {
                 Assert.Fail(e.Error.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Manual test to determine whether the client library supports setting a custom timeout.
+        /// https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/214/files
+        /// This test requires that you can have Fiddler or some other mechanism to delay the response.
+        /// For example, I used the Fiddler autoresponder with a captured response and set the latency in the responder.
+        /// I set the autoresponder latency to 10 seconds, and the client's timeout to 7 sec (2 minutes).
+        /// You'll need to remove the Ignore attribute to run this as well. 
+        /// </summary>
+        [TestMethod]
+        [Ignore]
+        public async Async.Task ManualAdHocTimeoutTest()
+        {
+            graphClient.HttpProvider.OverallTimeout = new TimeSpan(0, 0, 7);
+            try
+            {
+                User me = await graphClient.Me.Request().GetAsync();
+
+                Assert.Fail("Expected an exception if this was setup correctly.");
+            }
+            catch (ServiceException ex)
+            {
+                Assert.IsInstanceOfType(ex.InnerException, typeof(Async.TaskCanceledException), "Unexpected inner exception thrown.");
             }
         }
     }

--- a/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
         {
             // Get a groups collection. We'll use the first entry to add the extension. Results in a call to the service.
             IGraphServiceGroupsCollectionPage groupPage = await graphClient.Groups.Request().GetAsync();
-            graphClient.HttpProvider.OverallTimeout = new TimeSpan(5000000);
+
             // Create the extension property.
             OpenTypeExtension newExtension = new OpenTypeExtension();
             newExtension.ExtensionName = "com.contoso.trackingKey";


### PR DESCRIPTION
This will enable users to set the timeout like this:

```
// Change the timeout interval from 100 sec (default) to 200 sec.
graphClient.HttpProvider.OverallTimeout = new TimeSpan(0,3,20);
```