### PR TITLE
Remove redundant ProjectReference in Core.Test

### DIFF
--- a/tests/Microsoft.Graph.Core.Test/Microsoft.Graph.Core.Test.csproj
+++ b/tests/Microsoft.Graph.Core.Test/Microsoft.Graph.Core.Test.csproj
@@ -108,12 +108,6 @@
       <SubType>Designer</SubType>
     </None>
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj">
-      <Project>{9f04608c-d845-4445-83b1-e6d4eee38cbc}</Project>
-      <Name>Microsoft.Graph.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
   <Choose>
     <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
       <ItemGroup>


### PR DESCRIPTION
This ProjectReference was redundantly specified, causing errors with
some MSBuild versions.

Works around https://github.com/Microsoft/msbuild/issues/2874.

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Remove a second, redundant `ProjectReference` from `Microsoft.Graph.Core.Test.csproj` to `Microsoft.Graph.Core.csproj`.