### PR TITLE
Fix Duration serializer and serializer test

### DIFF
--- a/src/Microsoft.Graph.Core/Serialization/DurationConverter.cs
+++ b/src/Microsoft.Graph.Core/Serialization/DurationConverter.cs
@@ -32,10 +32,9 @@ namespace Microsoft.Graph
                 {
                     return null;
                 }
+                var value = (string)serializer.Deserialize(reader, typeof(string));
 
-                var value = (Microsoft.Graph.Duration)serializer.Deserialize(reader, typeof(Microsoft.Graph.Duration));
-
-                return value;
+                return new Duration(value);
             }
             catch (JsonSerializationException serializationException)
             {

--- a/tests/Microsoft.Graph.Core.Test/Serialization/DurationConverterTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Serialization/DurationConverterTests.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Graph.Core.Test.Serialization
     using Newtonsoft.Json;
     using System.IO;
 
-    [Ignore]
+    //[Ignore]
     [TestClass]
     public class DurationConverterTests
     { 
@@ -38,26 +38,11 @@ namespace Microsoft.Graph.Core.Test.Serialization
         [TestMethod]
         public void Duration_CanDeserialize()
         {
-            string json = @"{'meetingDuration': 'PT2H'}";
-            JsonTextReader reader = new JsonTextReader(new StringReader(json));
-
-            using (MemoryStream stream = new MemoryStream())
-            using (StreamWriter writer = new StreamWriter(stream))
-            {
-                writer.Write(json);
-            }
-
-                if (reader.Read())
-                {
-                    var durationConverter = new DurationConverter();
-                    var type = typeof(Duration);
-                var duration = durationConverter.ReadJson(reader, type, null, new Newtonsoft.Json.JsonSerializer());
-                Assert.IsTrue(type == duration.GetType());
-                }
-                else
-                {
-                    Assert.Fail("Did not read a JSON token.");
-                }
+            var json = "\"PT2H\"";
+            var serializer = new Serializer();
+            var derivedType = serializer.DeserializeObject<Duration>(json);
+            Assert.IsNotNull(derivedType, "Object not correctly deserialized.");
+            Assert.AreEqual(2, derivedType.TimeSpan.Hours);
         }
     }
 }


### PR DESCRIPTION
It looks like there was a bug in both the serializer and the test.

The serializer should deserialize the value to a string and then use the `Duration(string)` signature to create a Duration object.

The serializer test should not use a JSON key-value pair because a duration is only a value. I also used the same serializer logic in `SerializerTests.cs` because it was a bit cleaner.
