### PR TITLE
WebhookNotificationClass

### DIFF
--- a/src/Microsoft.Graph/Models/Extensions/Notification.cs
+++ b/src/Microsoft.Graph/Models/Extensions/Notification.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using Newtonsoft.Json;
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// Represents the notifications received from a webhook subscription.
+    /// </summary>
+    public class Notification
+    {
+        /// <summary>
+        /// Queued webhook notifications.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "value", Required = Required.Default)]
+        public List<NotificationValue> Values { get; set; }
+    }
+
+    /// <summary>
+    /// Represents a value in a received webhook notification.
+    /// </summary>
+    public class NotificationValue
+    {
+        /// <summary>
+        /// The ID for the subscription to which this notification belongs.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "subscriptionId", Required = Required.Default)]
+        public String SubscriptionId { get; set; }
+
+        /// <summary>
+        /// The expiration time for the subscription.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "subscriptionExpirationDateTime", Required = Required.Default)]
+        public String SubscriptionExpirationDateTime { get; set; }
+
+        /// <summary>
+        /// The clientState property specified in the subscription request.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "clientState", Required = Required.Default)]
+        public String ClientState { get; set; }
+
+        /// <summary>
+        /// The event type that caused the notification. For example, created on mail receive, or updated on marking a message read.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "changeType", Required = Required.Default)]
+        public String ChangeType { get; set; }
+
+        /// <summary>
+        /// The URI of the resource relative to https://graph.microsoft.com.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "resource", Required = Required.Default)]
+        public String Resource { get; set; }
+
+        /// <summary>
+        /// The object dependent on the resource being subscribed to.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "resourceData", Required = Required.Default)]
+        public NotificationResourceData ResourceData { get; set; }
+    }
+
+    /// <summary>
+    /// The object dependent on the resource being subscribed to.
+    /// </summary>
+    public class NotificationResourceData
+    {
+        /// <summary>
+        /// The OData entity type in Microsoft Graph that describes the represented object.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Required.Default)]
+        public String ODataType { get; set; }
+
+        /// <summary>
+        /// The OData identifier of the object.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.id", Required = Required.Default)]
+        public String ODataId { get; set; }
+
+        /// <summary>
+        /// The HTTP entity tag that represents a version of the object.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.etag", Required = Required.Default)]
+        public String ODataEtag { get; set; }
+
+        /// <summary>
+        /// The identifier of the object.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "id", Required = Required.Default)]
+        public String Id { get; set; }
+    }
+}


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->


<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Added the class "Notification" to parse the webhook notification message that is received, if changes were made to a microsoft graph resource (e.g. to outlook calendar events).
- This change was made to make the handling of webhook notifications easier.
- It was also proposed because of a request made in my stackoverflow post(see the link below).

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- https://stackoverflow.com/questions/49534591/subscription-notifications-in-graph-sdk/