### PR TITLE
Add response headers to the serialized response

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ The following sample applications are also available:
 * [Overview](docs/overview.md)
 * [Collections](docs/collections.md)
 * [Errors](docs/errors.md)
+* [Headers](docs/headers.md)
 * [Microsoft Graph API](https://graph.microsoft.io)
 * [Release notes](https://github.com/microsoftgraph/msgraph-sdk-dotnet/releases)
 

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -5,12 +5,13 @@ The .NET Client Library allows you to add your own custom request headers and in
 
 ## Adding request headers
 
-Custom headers can be added by creating a new header option collection and adding it to the request object:
+Custom headers can be added by creating a new option collection and adding it to the request object:
 
-```chsarp
-List<HeaderOption> options = new List<HeaderOption>();
+```csharp
+List<Option> options = new List<Option>();
 options.Add(new HeaderOption("Etag", etag));
 options.Add(new HeaderOption("If-Match", etag));
+options.Add(new QueryOption("$filter", filterQuery));
 
 var newObject = graphServiceClient
 	.Object
@@ -20,7 +21,7 @@ var newObject = graphServiceClient
 
 You can also pass headers in individually if you only need to include one header:
 
-```chsarp
+```csharp
 var newObject = graphServiceClient
 	.Object
 	.Request(new HeaderOption("Etag", etag))

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -1,0 +1,52 @@
+# Headers in the Microsoft Graph .NET Client Library
+
+
+The .NET Client Library allows you to add your own custom request headers and inspect the response headers that come back from the Graph service.
+
+## Adding request headers
+
+Custom headers can be added by creating a new header option collection and adding it to the request object:
+
+```chsarp
+List<HeaderOption> options = new List<HeaderOption>();
+options.Add(new HeaderOption("Etag", etag));
+options.Add(new HeaderOption("If-Match", etag));
+
+var newObject = graphServiceClient
+	.Object
+	.Request(options)
+	.Patch(updatedObject);
+```
+
+You can also pass headers in individually if you only need to include one header:
+
+```chsarp
+var newObject = graphServiceClient
+	.Object
+	.Request(new HeaderOption("Etag", etag))
+	.Patch(updatedObject);
+```
+
+## Reading response headers
+
+HTTP response data is available in the `AdditionalData` property bag of the response object. You can access both the `statusCode` of the response and the `responseHeaders` to get more information, such as the request ID, Content-Type, and other data that may be relevant to you that is not part of the object model inherently.
+
+To work with the response headers, you can deserialize the data using the client's serializer to make it easy to parse through the header dictionary:
+
+```csharp
+var user = await graphServiceClient....getAsync();
+	
+var statusCode = user.AdditionalData["statusCode"];
+var responseHeaders = user.AdditionalData["responseHeaders"];
+
+// Deserialize headers to dictionary for easy access to values
+var responseHeaderCollection = graphClient
+                    .HttpProvider
+                    .Serializer
+                    .DeserializeObject<Dictionary<string, List<string>>>(responseHeaders.ToString());
+
+var requestId = responseHeaderCollection["request-id"][0];
+```
+
+
+*Currently, requests that have a return type of `void` do not return response headers and cannot be inspected.*

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -50,4 +50,4 @@ var requestId = responseHeaderCollection["request-id"][0];
 ```
 
 
-*Currently, requests that have a return type of `void` do not return response headers and cannot be inspected.*
+*Currently, requests that have a return type of `void` or `Stream` do not return response headers and cannot be inspected.*

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -4,6 +4,7 @@
 * [Collections](./collections.md)
 * [Errors](./errors.md)
 * [Contributions](./contributions.md)
+* [Headers](./headers.md)
 * [FAQ](./FAQ.md)
 
 ## How do I work with...

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -129,8 +129,7 @@ namespace Microsoft.Graph
             {
                 if (response.Content != null)
                 {
-                    var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    responseString = AddHeadersToResponse(response, responseString);
+                    var responseString = await GetResponseString(response);
                     return this.Client.HttpProvider.Serializer.DeserializeObject<T>(responseString);
                 }
 
@@ -155,8 +154,7 @@ namespace Microsoft.Graph
             {
                 if (response.Content != null)
                 {
-                    var responseString = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-                    responseString = AddHeadersToResponse(response, responseString);
+                    var responseString = await GetResponseString(response);
                     return this.Client.HttpProvider.Serializer.DeserializeObject<T>(responseString);
                 }
 
@@ -429,20 +427,21 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Add response headers to serialized response
+        /// Get the response content string
         /// </summary>
-        /// <param name="response">The response object</param>
-        /// <param name="content">The string to append the headers to</param>
+        /// <param name="hrm">The response object</param>
         /// <returns>The full response string to return</returns>
-        private string AddHeadersToResponse(HttpResponseMessage response, string content)
+        private async Task<string> GetResponseString(HttpResponseMessage hrm)
         {
             var responseContent = "";
+
+            var content = await hrm.Content.ReadAsStringAsync().ConfigureAwait(false);
 
             //Only add headers if we are going to return a response body
             if (content.Length > 0)
             {
-                var responseHeaders = response.Headers;
-                var statusCode = response.StatusCode;
+                var responseHeaders = hrm.Headers;
+                var statusCode = hrm.StatusCode;
 
                 Dictionary<string, string[]> headerDictionary = responseHeaders.ToDictionary(x => x.Key, x => x.Value.ToArray());
                 var responseHeaderString = this.Client.HttpProvider.Serializer.SerializeObject(headerDictionary);

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -442,8 +442,14 @@ namespace Microsoft.Graph
             Dictionary<string, string[]> headerDictionary = responseHeaders.ToDictionary(x => x.Key, x => x.Value.ToArray());
             var responseHeaderString = this.Client.HttpProvider.Serializer.SerializeObject(headerDictionary);
 
-            var responseContent = content.Substring(0, content.Length - 1);
-            responseContent += ", \"responseHeaders\": " + responseHeaderString + ", ";
+            var responseContent = "";
+
+            if (content.Length > 0)
+            {
+                responseContent = content.Substring(0, content.Length - 1) + ", ";
+            }
+           
+            responseContent += "\"responseHeaders\": " + responseHeaderString + ", ";
             responseContent += "\"statusCode\": \"" + statusCode + "\"}";
 
             return responseContent;

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -436,21 +436,21 @@ namespace Microsoft.Graph
         /// <returns>The full response string to return</returns>
         private string AddHeadersToResponse(HttpResponseMessage response, string content)
         {
-            var responseHeaders = response.Headers;
-            var statusCode = response.StatusCode;
-
-            Dictionary<string, string[]> headerDictionary = responseHeaders.ToDictionary(x => x.Key, x => x.Value.ToArray());
-            var responseHeaderString = this.Client.HttpProvider.Serializer.SerializeObject(headerDictionary);
-
             var responseContent = "";
 
+            //Only add headers if we are going to return a response body
             if (content.Length > 0)
             {
+                var responseHeaders = response.Headers;
+                var statusCode = response.StatusCode;
+
+                Dictionary<string, string[]> headerDictionary = responseHeaders.ToDictionary(x => x.Key, x => x.Value.ToArray());
+                var responseHeaderString = this.Client.HttpProvider.Serializer.SerializeObject(headerDictionary);
+
                 responseContent = content.Substring(0, content.Length - 1) + ", ";
+                responseContent += "\"responseHeaders\": " + responseHeaderString + ", ";
+                responseContent += "\"statusCode\": \"" + statusCode + "\"}";
             }
-           
-            responseContent += "\"responseHeaders\": " + responseHeaderString + ", ";
-            responseContent += "\"statusCode\": \"" + statusCode + "\"}";
 
             return responseContent;
         }

--- a/tests/Microsoft.Graph.Core.Test/Mocks/MockSerializer.cs
+++ b/tests/Microsoft.Graph.Core.Test/Mocks/MockSerializer.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Graph.Core.Test.Mocks
         public MockSerializer()
             : base(MockBehavior.Strict)
         {
+            this.Setup(
+                provider => provider.SerializeObject(It.IsAny<object>()))
+                .Returns(It.IsAny<string>);
         }
     }
 }

--- a/tests/Microsoft.Graph.Core.Test/Mocks/MockSerializer.cs
+++ b/tests/Microsoft.Graph.Core.Test/Mocks/MockSerializer.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Graph.Core.Test.Mocks
         {
             this.Setup(
                 provider => provider.SerializeObject(It.IsAny<object>()))
-                .Returns(It.IsAny<string>);
+                .Returns("{\"key\": \"value\"}");
         }
     }
 }

--- a/tests/Microsoft.Graph.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/BaseRequestTests.cs
@@ -206,6 +206,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
                 var responseItem = await baseRequest.SendAsync<DerivedTypeClass>("string", CancellationToken.None);
                 Assert.IsNotNull(responseItem.AdditionalData["responseHeaders"], "No response headers available");
+                Assert.AreEqual(expectedResponseItem.AdditionalData["responseHeaders"], responseItem.AdditionalData["responseHeaders"], "Unexpected response headers");
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockSerializer.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockSerializer.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
         {
             this.Setup(
                 provider => provider.SerializeObject(It.IsAny<object>()))
-                .Returns(It.IsAny<string>);
+                .Returns("{\"key\": \"value\"}");
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockSerializer.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockSerializer.cs
@@ -15,6 +15,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
         public MockSerializer()
             : base(MockBehavior.Strict)
         {
+            this.Setup(
+                provider => provider.SerializeObject(It.IsAny<object>()))
+                .Returns(It.IsAny<string>);
         }
     }
 }

--- a/tests/Microsoft.Graph.Test/Requests/Functional/OneDriveTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/OneDriveTests.cs
@@ -53,9 +53,9 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     //props.FileSystemInfo.LastModifiedDateTime = System.DateTimeOffset.Now;
 
                     // Get the provider. 
-                    // POST /v1.0/drive/items/01KGPRHTV6Y2GOVW7725BZO354PWSELRRZ:/_hamiltion.png:/microsoft.graph.createUploadSession
+                    // POST /v1.0/drive/items/01KA5JMEBZ7FQ7QYBXKJE3X3THBVZLQIUS:/_hamiltion.png:/microsoft.graph.createUploadSession
                     // The CreateUploadSesssion action doesn't seem to support the options stated in the metadata.
-                    var uploadSession = await graphClient.Drive.Items["01KGPRHTV6Y2GOVW7725BZO354PWSELRRZ"].ItemWithPath("_hamilton.png").CreateUploadSession().Request().PostAsync();
+                    var uploadSession = await graphClient.Drive.Items["01KA5JMEBZ7FQ7QYBXKJE3X3THBVZLQIUS"].ItemWithPath("_hamilton.png").CreateUploadSession().Request().PostAsync();
 
                     var maxChunkSize = 320 * 1024; // 320 KB - Change this to your chunk size. 5MB is the default.
                     var provider = new ChunkedUploadProvider(uploadSession, graphClient, ms, maxChunkSize);
@@ -339,7 +339,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
         }
 
         // Assumption: test tenant has a file name that starts with 'Timesheet'.
-        // Assumption: there is a user with an email alias of alexd and a display name of Alex Darrow in the test tenant.
+        // Assumption: there is a user with an email alias of alexw and a display name of Alex Wilber in the test tenant.
         [TestMethod]
         public async Async.Task OneDriveInvite()
         {
@@ -361,7 +361,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 {
                     new DriveRecipient()
                     {
-                        Email = $"alexd@{domain}"
+                        Email = $"alexw@{domain}"
                     }
                 };
 
@@ -377,7 +377,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
                                                            .Request()
                                                            .PostAsync();
 
-                Assert.AreEqual("Alex Darrow", inviteCollection[0].GrantedTo.User.DisplayName);
+                Assert.AreEqual("Alex Wilber", inviteCollection[0].GrantedTo.User.DisplayName);
             }
             catch (Microsoft.Graph.ServiceException e)
             {

--- a/tests/Microsoft.Graph.Test/Requests/Functional/PlannerTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/PlannerTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
         {
             if (planId == "")
             {
-                planId = "HJLUP2ZwhE6-Gd0Sp3UMB2QAHsEe"; // OnlineMarketingGroup PlanId in test tenant.
+                planId = "X64sGtz57EO5q2KVrqEfVmUAEAYw"; // OnlineMarketingGroup PlanId in test tenant.
             }
 
             try


### PR DESCRIPTION
This allows them to get deserialized down the line, typically by the default `Serializer` class into `AdditionalData["responseHeaders"]` and `AdditionalData["statusCode"`.

[BaseRequest.cs](https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/response-headers?expand=1#diff-f0b9dd257bbefc270429de4a743d233b) - add headers to the response content. If the content stream is null, do not add headers, because the serializer is expecting a null object back. Because these will get picked up by the individual models later in the deserialization process, we need to temporarily re-serialize the headers and append them to the content stream to "trick" the serializer into deserializing them back into the object as additional data.

[MockSerializer](https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/response-headers?expand=1#diff-bd80effa99372c9b79f204611cdb5e55) - Added SerializeObject method to MockSerializer for both .NET and .NET Core tests (required for MockBehavior.Strict, also used in the BaseRequestTest.cs)

[BaseRequestTests](https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/response-headers?expand=1#diff-9084307af9a1903cf874e29423288c53) - Similar behavior to `SendAsync` test, but with content and headers set. Content must be set in order for headers to be attached. 

[OneDriveTests](https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/response-headers?expand=1#diff-73f67618397ff61d1687ddfa1ce6ae91) and [PlannerTests](https://github.com/microsoftgraph/msgraph-sdk-dotnet/compare/response-headers?expand=1#diff-2850e5d22ff762a082a5a24e4ea4d954) - Updated test credentials to verify functional tests pass with response header updates.