### PR TITLE
With reference request delete method

### DIFF
--- a/src/Microsoft.Graph/Requests/Generated/AdministrativeUnitWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/AdministrativeUnitWithReferenceRequest.cs
@@ -55,6 +55,76 @@ namespace Microsoft.Graph
             return retrievedEntity;
         }
 
+		/// <summary>
+        /// Creates the specified AdministrativeUnit using POST.
+        /// </summary>
+        /// <param name="administrativeUnitToCreate">The AdministrativeUnit to create.</param>
+        /// <returns>The created AdministrativeUnit.</returns>
+        public System.Threading.Tasks.Task<AdministrativeUnit> CreateAsync(AdministrativeUnit administrativeUnitToCreate)
+        {
+            return this.CreateAsync(administrativeUnitToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified AdministrativeUnit using POST.
+        /// </summary>
+        /// <param name="administrativeUnitToCreate">The AdministrativeUnit to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created AdministrativeUnit.</returns>
+        public async System.Threading.Tasks.Task<AdministrativeUnit> CreateAsync(AdministrativeUnit administrativeUnitToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            var newEntity = await this.SendAsync<AdministrativeUnit>(administrativeUnitToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+
+		/// <summary>
+        /// Updates the specified AdministrativeUnit using PATCH.
+        /// </summary>
+        /// <param name="administrativeUnitToUpdate">The AdministrativeUnit to update.</param>
+        /// <returns>The updated AdministrativeUnit.</returns>
+        public System.Threading.Tasks.Task<AdministrativeUnit> UpdateAsync(AdministrativeUnit administrativeUnitToUpdate)
+        {
+            return this.UpdateAsync(administrativeUnitToUpdate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the specified AdministrativeUnit using PATCH.
+        /// </summary>
+        /// <param name="administrativeUnitToUpdate">The AdministrativeUnit to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated AdministrativeUnit.</returns>
+        public async System.Threading.Tasks.Task<AdministrativeUnit> UpdateAsync(AdministrativeUnit administrativeUnitToUpdate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PATCH";
+            var updatedEntity = await this.SendAsync<AdministrativeUnit>(administrativeUnitToUpdate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(updatedEntity);
+            return updatedEntity;
+        }
+
+		/// <summary>
+        /// Deletes the specified AdministrativeUnit.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        public System.Threading.Tasks.Task DeleteAsync()
+        {
+            return this.DeleteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the specified AdministrativeUnit.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "DELETE";
+            await this.SendAsync<AdministrativeUnit>(null, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/AdministrativeUnitWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/AdministrativeUnitWithReferenceRequest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "POST";
             var newEntity = await this.SendAsync<AdministrativeUnit>(administrativeUnitToCreate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }
 
@@ -101,7 +100,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "PATCH";
             var updatedEntity = await this.SendAsync<AdministrativeUnit>(administrativeUnitToUpdate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }
 

--- a/src/Microsoft.Graph/Requests/Generated/DirectoryObjectWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/DirectoryObjectWithReferenceRequest.cs
@@ -55,6 +55,76 @@ namespace Microsoft.Graph
             return retrievedEntity;
         }
 
+		/// <summary>
+        /// Creates the specified DirectoryObject using POST.
+        /// </summary>
+        /// <param name="directoryObjectToCreate">The DirectoryObject to create.</param>
+        /// <returns>The created DirectoryObject.</returns>
+        public System.Threading.Tasks.Task<DirectoryObject> CreateAsync(DirectoryObject directoryObjectToCreate)
+        {
+            return this.CreateAsync(directoryObjectToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified DirectoryObject using POST.
+        /// </summary>
+        /// <param name="directoryObjectToCreate">The DirectoryObject to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created DirectoryObject.</returns>
+        public async System.Threading.Tasks.Task<DirectoryObject> CreateAsync(DirectoryObject directoryObjectToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            var newEntity = await this.SendAsync<DirectoryObject>(directoryObjectToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+
+		/// <summary>
+        /// Updates the specified DirectoryObject using PATCH.
+        /// </summary>
+        /// <param name="directoryObjectToUpdate">The DirectoryObject to update.</param>
+        /// <returns>The updated DirectoryObject.</returns>
+        public System.Threading.Tasks.Task<DirectoryObject> UpdateAsync(DirectoryObject directoryObjectToUpdate)
+        {
+            return this.UpdateAsync(directoryObjectToUpdate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the specified DirectoryObject using PATCH.
+        /// </summary>
+        /// <param name="directoryObjectToUpdate">The DirectoryObject to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated DirectoryObject.</returns>
+        public async System.Threading.Tasks.Task<DirectoryObject> UpdateAsync(DirectoryObject directoryObjectToUpdate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PATCH";
+            var updatedEntity = await this.SendAsync<DirectoryObject>(directoryObjectToUpdate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(updatedEntity);
+            return updatedEntity;
+        }
+
+		/// <summary>
+        /// Deletes the specified DirectoryObject.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        public System.Threading.Tasks.Task DeleteAsync()
+        {
+            return this.DeleteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the specified DirectoryObject.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "DELETE";
+            await this.SendAsync<DirectoryObject>(null, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/DirectoryObjectWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/DirectoryObjectWithReferenceRequest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "POST";
             var newEntity = await this.SendAsync<DirectoryObject>(directoryObjectToCreate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }
 
@@ -101,7 +100,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "PATCH";
             var updatedEntity = await this.SendAsync<DirectoryObject>(directoryObjectToUpdate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }
 

--- a/src/Microsoft.Graph/Requests/Generated/EducationClassWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/EducationClassWithReferenceRequest.cs
@@ -55,6 +55,76 @@ namespace Microsoft.Graph
             return retrievedEntity;
         }
 
+		/// <summary>
+        /// Creates the specified EducationClass using POST.
+        /// </summary>
+        /// <param name="educationClassToCreate">The EducationClass to create.</param>
+        /// <returns>The created EducationClass.</returns>
+        public System.Threading.Tasks.Task<EducationClass> CreateAsync(EducationClass educationClassToCreate)
+        {
+            return this.CreateAsync(educationClassToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified EducationClass using POST.
+        /// </summary>
+        /// <param name="educationClassToCreate">The EducationClass to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created EducationClass.</returns>
+        public async System.Threading.Tasks.Task<EducationClass> CreateAsync(EducationClass educationClassToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            var newEntity = await this.SendAsync<EducationClass>(educationClassToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+
+		/// <summary>
+        /// Updates the specified EducationClass using PATCH.
+        /// </summary>
+        /// <param name="educationClassToUpdate">The EducationClass to update.</param>
+        /// <returns>The updated EducationClass.</returns>
+        public System.Threading.Tasks.Task<EducationClass> UpdateAsync(EducationClass educationClassToUpdate)
+        {
+            return this.UpdateAsync(educationClassToUpdate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the specified EducationClass using PATCH.
+        /// </summary>
+        /// <param name="educationClassToUpdate">The EducationClass to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated EducationClass.</returns>
+        public async System.Threading.Tasks.Task<EducationClass> UpdateAsync(EducationClass educationClassToUpdate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PATCH";
+            var updatedEntity = await this.SendAsync<EducationClass>(educationClassToUpdate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(updatedEntity);
+            return updatedEntity;
+        }
+
+		/// <summary>
+        /// Deletes the specified EducationClass.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        public System.Threading.Tasks.Task DeleteAsync()
+        {
+            return this.DeleteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the specified EducationClass.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "DELETE";
+            await this.SendAsync<EducationClass>(null, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/EducationClassWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/EducationClassWithReferenceRequest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "POST";
             var newEntity = await this.SendAsync<EducationClass>(educationClassToCreate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }
 
@@ -101,7 +100,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "PATCH";
             var updatedEntity = await this.SendAsync<EducationClass>(educationClassToUpdate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }
 

--- a/src/Microsoft.Graph/Requests/Generated/EducationSchoolWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/EducationSchoolWithReferenceRequest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "POST";
             var newEntity = await this.SendAsync<EducationSchool>(educationSchoolToCreate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }
 
@@ -101,7 +100,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "PATCH";
             var updatedEntity = await this.SendAsync<EducationSchool>(educationSchoolToUpdate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }
 

--- a/src/Microsoft.Graph/Requests/Generated/EducationSchoolWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/EducationSchoolWithReferenceRequest.cs
@@ -55,6 +55,76 @@ namespace Microsoft.Graph
             return retrievedEntity;
         }
 
+		/// <summary>
+        /// Creates the specified EducationSchool using POST.
+        /// </summary>
+        /// <param name="educationSchoolToCreate">The EducationSchool to create.</param>
+        /// <returns>The created EducationSchool.</returns>
+        public System.Threading.Tasks.Task<EducationSchool> CreateAsync(EducationSchool educationSchoolToCreate)
+        {
+            return this.CreateAsync(educationSchoolToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified EducationSchool using POST.
+        /// </summary>
+        /// <param name="educationSchoolToCreate">The EducationSchool to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created EducationSchool.</returns>
+        public async System.Threading.Tasks.Task<EducationSchool> CreateAsync(EducationSchool educationSchoolToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            var newEntity = await this.SendAsync<EducationSchool>(educationSchoolToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+
+		/// <summary>
+        /// Updates the specified EducationSchool using PATCH.
+        /// </summary>
+        /// <param name="educationSchoolToUpdate">The EducationSchool to update.</param>
+        /// <returns>The updated EducationSchool.</returns>
+        public System.Threading.Tasks.Task<EducationSchool> UpdateAsync(EducationSchool educationSchoolToUpdate)
+        {
+            return this.UpdateAsync(educationSchoolToUpdate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the specified EducationSchool using PATCH.
+        /// </summary>
+        /// <param name="educationSchoolToUpdate">The EducationSchool to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated EducationSchool.</returns>
+        public async System.Threading.Tasks.Task<EducationSchool> UpdateAsync(EducationSchool educationSchoolToUpdate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PATCH";
+            var updatedEntity = await this.SendAsync<EducationSchool>(educationSchoolToUpdate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(updatedEntity);
+            return updatedEntity;
+        }
+
+		/// <summary>
+        /// Deletes the specified EducationSchool.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        public System.Threading.Tasks.Task DeleteAsync()
+        {
+            return this.DeleteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the specified EducationSchool.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "DELETE";
+            await this.SendAsync<EducationSchool>(null, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/EducationUserWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/EducationUserWithReferenceRequest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "POST";
             var newEntity = await this.SendAsync<EducationUser>(educationUserToCreate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }
 
@@ -101,7 +100,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "PATCH";
             var updatedEntity = await this.SendAsync<EducationUser>(educationUserToUpdate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }
 

--- a/src/Microsoft.Graph/Requests/Generated/EducationUserWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/EducationUserWithReferenceRequest.cs
@@ -55,6 +55,76 @@ namespace Microsoft.Graph
             return retrievedEntity;
         }
 
+		/// <summary>
+        /// Creates the specified EducationUser using POST.
+        /// </summary>
+        /// <param name="educationUserToCreate">The EducationUser to create.</param>
+        /// <returns>The created EducationUser.</returns>
+        public System.Threading.Tasks.Task<EducationUser> CreateAsync(EducationUser educationUserToCreate)
+        {
+            return this.CreateAsync(educationUserToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified EducationUser using POST.
+        /// </summary>
+        /// <param name="educationUserToCreate">The EducationUser to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created EducationUser.</returns>
+        public async System.Threading.Tasks.Task<EducationUser> CreateAsync(EducationUser educationUserToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            var newEntity = await this.SendAsync<EducationUser>(educationUserToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+
+		/// <summary>
+        /// Updates the specified EducationUser using PATCH.
+        /// </summary>
+        /// <param name="educationUserToUpdate">The EducationUser to update.</param>
+        /// <returns>The updated EducationUser.</returns>
+        public System.Threading.Tasks.Task<EducationUser> UpdateAsync(EducationUser educationUserToUpdate)
+        {
+            return this.UpdateAsync(educationUserToUpdate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the specified EducationUser using PATCH.
+        /// </summary>
+        /// <param name="educationUserToUpdate">The EducationUser to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated EducationUser.</returns>
+        public async System.Threading.Tasks.Task<EducationUser> UpdateAsync(EducationUser educationUserToUpdate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PATCH";
+            var updatedEntity = await this.SendAsync<EducationUser>(educationUserToUpdate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(updatedEntity);
+            return updatedEntity;
+        }
+
+		/// <summary>
+        /// Deletes the specified EducationUser.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        public System.Threading.Tasks.Task DeleteAsync()
+        {
+            return this.DeleteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the specified EducationUser.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "DELETE";
+            await this.SendAsync<EducationUser>(null, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/GroupWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/GroupWithReferenceRequest.cs
@@ -55,6 +55,76 @@ namespace Microsoft.Graph
             return retrievedEntity;
         }
 
+		/// <summary>
+        /// Creates the specified Group using POST.
+        /// </summary>
+        /// <param name="groupToCreate">The Group to create.</param>
+        /// <returns>The created Group.</returns>
+        public System.Threading.Tasks.Task<Group> CreateAsync(Group groupToCreate)
+        {
+            return this.CreateAsync(groupToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified Group using POST.
+        /// </summary>
+        /// <param name="groupToCreate">The Group to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created Group.</returns>
+        public async System.Threading.Tasks.Task<Group> CreateAsync(Group groupToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            var newEntity = await this.SendAsync<Group>(groupToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+
+		/// <summary>
+        /// Updates the specified Group using PATCH.
+        /// </summary>
+        /// <param name="groupToUpdate">The Group to update.</param>
+        /// <returns>The updated Group.</returns>
+        public System.Threading.Tasks.Task<Group> UpdateAsync(Group groupToUpdate)
+        {
+            return this.UpdateAsync(groupToUpdate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the specified Group using PATCH.
+        /// </summary>
+        /// <param name="groupToUpdate">The Group to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated Group.</returns>
+        public async System.Threading.Tasks.Task<Group> UpdateAsync(Group groupToUpdate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PATCH";
+            var updatedEntity = await this.SendAsync<Group>(groupToUpdate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(updatedEntity);
+            return updatedEntity;
+        }
+
+		/// <summary>
+        /// Deletes the specified Group.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        public System.Threading.Tasks.Task DeleteAsync()
+        {
+            return this.DeleteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the specified Group.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "DELETE";
+            await this.SendAsync<Group>(null, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/GroupWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/GroupWithReferenceRequest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "POST";
             var newEntity = await this.SendAsync<Group>(groupToCreate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }
 
@@ -101,7 +100,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "PATCH";
             var updatedEntity = await this.SendAsync<Group>(groupToUpdate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }
 

--- a/src/Microsoft.Graph/Requests/Generated/IAdministrativeUnitWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IAdministrativeUnitWithReferenceRequest.cs
@@ -32,6 +32,47 @@ namespace Microsoft.Graph
         /// <returns>The AdministrativeUnit.</returns>
         System.Threading.Tasks.Task<AdministrativeUnit> GetAsync(CancellationToken cancellationToken);
 
+		/// <summary>
+        /// Creates the specified AdministrativeUnit using PUT.
+        /// </summary>
+        /// <param name="administrativeUnitToCreate">The AdministrativeUnit to create.</param>
+        /// <returns>The created AdministrativeUnit.</returns>
+        System.Threading.Tasks.Task<AdministrativeUnit> CreateAsync(AdministrativeUnit administrativeUnitToCreate);        /// <summary>
+        /// Creates the specified AdministrativeUnit using PUT.
+        /// </summary>
+        /// <param name="administrativeUnitToCreate">The AdministrativeUnit to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created AdministrativeUnit.</returns>
+        System.Threading.Tasks.Task<AdministrativeUnit> CreateAsync(AdministrativeUnit administrativeUnitToCreate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Updates the specified AdministrativeUnit using PATCH.
+        /// </summary>
+        /// <param name="administrativeUnitToUpdate">The AdministrativeUnit to update.</param>
+        /// <returns>The updated AdministrativeUnit.</returns>
+        System.Threading.Tasks.Task<AdministrativeUnit> UpdateAsync(AdministrativeUnit administrativeUnitToUpdate);
+
+        /// <summary>
+        /// Updates the specified AdministrativeUnit using PATCH.
+        /// </summary>
+        /// <param name="administrativeUnitToUpdate">The AdministrativeUnit to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated AdministrativeUnit.</returns>
+        System.Threading.Tasks.Task<AdministrativeUnit> UpdateAsync(AdministrativeUnit administrativeUnitToUpdate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Deletes the specified AdministrativeUnit.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync();
+
+        /// <summary>
+        /// Deletes the specified AdministrativeUnit.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/IDirectoryObjectWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IDirectoryObjectWithReferenceRequest.cs
@@ -32,6 +32,47 @@ namespace Microsoft.Graph
         /// <returns>The DirectoryObject.</returns>
         System.Threading.Tasks.Task<DirectoryObject> GetAsync(CancellationToken cancellationToken);
 
+		/// <summary>
+        /// Creates the specified DirectoryObject using PUT.
+        /// </summary>
+        /// <param name="directoryObjectToCreate">The DirectoryObject to create.</param>
+        /// <returns>The created DirectoryObject.</returns>
+        System.Threading.Tasks.Task<DirectoryObject> CreateAsync(DirectoryObject directoryObjectToCreate);        /// <summary>
+        /// Creates the specified DirectoryObject using PUT.
+        /// </summary>
+        /// <param name="directoryObjectToCreate">The DirectoryObject to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created DirectoryObject.</returns>
+        System.Threading.Tasks.Task<DirectoryObject> CreateAsync(DirectoryObject directoryObjectToCreate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Updates the specified DirectoryObject using PATCH.
+        /// </summary>
+        /// <param name="directoryObjectToUpdate">The DirectoryObject to update.</param>
+        /// <returns>The updated DirectoryObject.</returns>
+        System.Threading.Tasks.Task<DirectoryObject> UpdateAsync(DirectoryObject directoryObjectToUpdate);
+
+        /// <summary>
+        /// Updates the specified DirectoryObject using PATCH.
+        /// </summary>
+        /// <param name="directoryObjectToUpdate">The DirectoryObject to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated DirectoryObject.</returns>
+        System.Threading.Tasks.Task<DirectoryObject> UpdateAsync(DirectoryObject directoryObjectToUpdate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Deletes the specified DirectoryObject.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync();
+
+        /// <summary>
+        /// Deletes the specified DirectoryObject.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/IEducationClassWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IEducationClassWithReferenceRequest.cs
@@ -32,6 +32,47 @@ namespace Microsoft.Graph
         /// <returns>The EducationClass.</returns>
         System.Threading.Tasks.Task<EducationClass> GetAsync(CancellationToken cancellationToken);
 
+		/// <summary>
+        /// Creates the specified EducationClass using PUT.
+        /// </summary>
+        /// <param name="educationClassToCreate">The EducationClass to create.</param>
+        /// <returns>The created EducationClass.</returns>
+        System.Threading.Tasks.Task<EducationClass> CreateAsync(EducationClass educationClassToCreate);        /// <summary>
+        /// Creates the specified EducationClass using PUT.
+        /// </summary>
+        /// <param name="educationClassToCreate">The EducationClass to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created EducationClass.</returns>
+        System.Threading.Tasks.Task<EducationClass> CreateAsync(EducationClass educationClassToCreate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Updates the specified EducationClass using PATCH.
+        /// </summary>
+        /// <param name="educationClassToUpdate">The EducationClass to update.</param>
+        /// <returns>The updated EducationClass.</returns>
+        System.Threading.Tasks.Task<EducationClass> UpdateAsync(EducationClass educationClassToUpdate);
+
+        /// <summary>
+        /// Updates the specified EducationClass using PATCH.
+        /// </summary>
+        /// <param name="educationClassToUpdate">The EducationClass to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated EducationClass.</returns>
+        System.Threading.Tasks.Task<EducationClass> UpdateAsync(EducationClass educationClassToUpdate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Deletes the specified EducationClass.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync();
+
+        /// <summary>
+        /// Deletes the specified EducationClass.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/IEducationSchoolWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IEducationSchoolWithReferenceRequest.cs
@@ -32,6 +32,47 @@ namespace Microsoft.Graph
         /// <returns>The EducationSchool.</returns>
         System.Threading.Tasks.Task<EducationSchool> GetAsync(CancellationToken cancellationToken);
 
+		/// <summary>
+        /// Creates the specified EducationSchool using PUT.
+        /// </summary>
+        /// <param name="educationSchoolToCreate">The EducationSchool to create.</param>
+        /// <returns>The created EducationSchool.</returns>
+        System.Threading.Tasks.Task<EducationSchool> CreateAsync(EducationSchool educationSchoolToCreate);        /// <summary>
+        /// Creates the specified EducationSchool using PUT.
+        /// </summary>
+        /// <param name="educationSchoolToCreate">The EducationSchool to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created EducationSchool.</returns>
+        System.Threading.Tasks.Task<EducationSchool> CreateAsync(EducationSchool educationSchoolToCreate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Updates the specified EducationSchool using PATCH.
+        /// </summary>
+        /// <param name="educationSchoolToUpdate">The EducationSchool to update.</param>
+        /// <returns>The updated EducationSchool.</returns>
+        System.Threading.Tasks.Task<EducationSchool> UpdateAsync(EducationSchool educationSchoolToUpdate);
+
+        /// <summary>
+        /// Updates the specified EducationSchool using PATCH.
+        /// </summary>
+        /// <param name="educationSchoolToUpdate">The EducationSchool to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated EducationSchool.</returns>
+        System.Threading.Tasks.Task<EducationSchool> UpdateAsync(EducationSchool educationSchoolToUpdate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Deletes the specified EducationSchool.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync();
+
+        /// <summary>
+        /// Deletes the specified EducationSchool.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/IEducationUserWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IEducationUserWithReferenceRequest.cs
@@ -32,6 +32,47 @@ namespace Microsoft.Graph
         /// <returns>The EducationUser.</returns>
         System.Threading.Tasks.Task<EducationUser> GetAsync(CancellationToken cancellationToken);
 
+		/// <summary>
+        /// Creates the specified EducationUser using PUT.
+        /// </summary>
+        /// <param name="educationUserToCreate">The EducationUser to create.</param>
+        /// <returns>The created EducationUser.</returns>
+        System.Threading.Tasks.Task<EducationUser> CreateAsync(EducationUser educationUserToCreate);        /// <summary>
+        /// Creates the specified EducationUser using PUT.
+        /// </summary>
+        /// <param name="educationUserToCreate">The EducationUser to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created EducationUser.</returns>
+        System.Threading.Tasks.Task<EducationUser> CreateAsync(EducationUser educationUserToCreate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Updates the specified EducationUser using PATCH.
+        /// </summary>
+        /// <param name="educationUserToUpdate">The EducationUser to update.</param>
+        /// <returns>The updated EducationUser.</returns>
+        System.Threading.Tasks.Task<EducationUser> UpdateAsync(EducationUser educationUserToUpdate);
+
+        /// <summary>
+        /// Updates the specified EducationUser using PATCH.
+        /// </summary>
+        /// <param name="educationUserToUpdate">The EducationUser to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated EducationUser.</returns>
+        System.Threading.Tasks.Task<EducationUser> UpdateAsync(EducationUser educationUserToUpdate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Deletes the specified EducationUser.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync();
+
+        /// <summary>
+        /// Deletes the specified EducationUser.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/IGroupWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IGroupWithReferenceRequest.cs
@@ -32,6 +32,47 @@ namespace Microsoft.Graph
         /// <returns>The Group.</returns>
         System.Threading.Tasks.Task<Group> GetAsync(CancellationToken cancellationToken);
 
+		/// <summary>
+        /// Creates the specified Group using PUT.
+        /// </summary>
+        /// <param name="groupToCreate">The Group to create.</param>
+        /// <returns>The created Group.</returns>
+        System.Threading.Tasks.Task<Group> CreateAsync(Group groupToCreate);        /// <summary>
+        /// Creates the specified Group using PUT.
+        /// </summary>
+        /// <param name="groupToCreate">The Group to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created Group.</returns>
+        System.Threading.Tasks.Task<Group> CreateAsync(Group groupToCreate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Updates the specified Group using PATCH.
+        /// </summary>
+        /// <param name="groupToUpdate">The Group to update.</param>
+        /// <returns>The updated Group.</returns>
+        System.Threading.Tasks.Task<Group> UpdateAsync(Group groupToUpdate);
+
+        /// <summary>
+        /// Updates the specified Group using PATCH.
+        /// </summary>
+        /// <param name="groupToUpdate">The Group to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated Group.</returns>
+        System.Threading.Tasks.Task<Group> UpdateAsync(Group groupToUpdate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Deletes the specified Group.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync();
+
+        /// <summary>
+        /// Deletes the specified Group.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/IUserActivityWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IUserActivityWithReferenceRequest.cs
@@ -32,6 +32,47 @@ namespace Microsoft.Graph
         /// <returns>The UserActivity.</returns>
         System.Threading.Tasks.Task<UserActivity> GetAsync(CancellationToken cancellationToken);
 
+		/// <summary>
+        /// Creates the specified UserActivity using PUT.
+        /// </summary>
+        /// <param name="userActivityToCreate">The UserActivity to create.</param>
+        /// <returns>The created UserActivity.</returns>
+        System.Threading.Tasks.Task<UserActivity> CreateAsync(UserActivity userActivityToCreate);        /// <summary>
+        /// Creates the specified UserActivity using PUT.
+        /// </summary>
+        /// <param name="userActivityToCreate">The UserActivity to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created UserActivity.</returns>
+        System.Threading.Tasks.Task<UserActivity> CreateAsync(UserActivity userActivityToCreate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Updates the specified UserActivity using PATCH.
+        /// </summary>
+        /// <param name="userActivityToUpdate">The UserActivity to update.</param>
+        /// <returns>The updated UserActivity.</returns>
+        System.Threading.Tasks.Task<UserActivity> UpdateAsync(UserActivity userActivityToUpdate);
+
+        /// <summary>
+        /// Updates the specified UserActivity using PATCH.
+        /// </summary>
+        /// <param name="userActivityToUpdate">The UserActivity to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated UserActivity.</returns>
+        System.Threading.Tasks.Task<UserActivity> UpdateAsync(UserActivity userActivityToUpdate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Deletes the specified UserActivity.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync();
+
+        /// <summary>
+        /// Deletes the specified UserActivity.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/IUserWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/IUserWithReferenceRequest.cs
@@ -32,6 +32,47 @@ namespace Microsoft.Graph
         /// <returns>The User.</returns>
         System.Threading.Tasks.Task<User> GetAsync(CancellationToken cancellationToken);
 
+		/// <summary>
+        /// Creates the specified User using PUT.
+        /// </summary>
+        /// <param name="userToCreate">The User to create.</param>
+        /// <returns>The created User.</returns>
+        System.Threading.Tasks.Task<User> CreateAsync(User userToCreate);        /// <summary>
+        /// Creates the specified User using PUT.
+        /// </summary>
+        /// <param name="userToCreate">The User to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created User.</returns>
+        System.Threading.Tasks.Task<User> CreateAsync(User userToCreate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Updates the specified User using PATCH.
+        /// </summary>
+        /// <param name="userToUpdate">The User to update.</param>
+        /// <returns>The updated User.</returns>
+        System.Threading.Tasks.Task<User> UpdateAsync(User userToUpdate);
+
+        /// <summary>
+        /// Updates the specified User using PATCH.
+        /// </summary>
+        /// <param name="userToUpdate">The User to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated User.</returns>
+        System.Threading.Tasks.Task<User> UpdateAsync(User userToUpdate, CancellationToken cancellationToken);
+
+		/// <summary>
+        /// Deletes the specified User.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync();
+
+        /// <summary>
+        /// Deletes the specified User.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken);
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/UserActivityWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/UserActivityWithReferenceRequest.cs
@@ -55,6 +55,76 @@ namespace Microsoft.Graph
             return retrievedEntity;
         }
 
+		/// <summary>
+        /// Creates the specified UserActivity using POST.
+        /// </summary>
+        /// <param name="userActivityToCreate">The UserActivity to create.</param>
+        /// <returns>The created UserActivity.</returns>
+        public System.Threading.Tasks.Task<UserActivity> CreateAsync(UserActivity userActivityToCreate)
+        {
+            return this.CreateAsync(userActivityToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified UserActivity using POST.
+        /// </summary>
+        /// <param name="userActivityToCreate">The UserActivity to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created UserActivity.</returns>
+        public async System.Threading.Tasks.Task<UserActivity> CreateAsync(UserActivity userActivityToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            var newEntity = await this.SendAsync<UserActivity>(userActivityToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+
+		/// <summary>
+        /// Updates the specified UserActivity using PATCH.
+        /// </summary>
+        /// <param name="userActivityToUpdate">The UserActivity to update.</param>
+        /// <returns>The updated UserActivity.</returns>
+        public System.Threading.Tasks.Task<UserActivity> UpdateAsync(UserActivity userActivityToUpdate)
+        {
+            return this.UpdateAsync(userActivityToUpdate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the specified UserActivity using PATCH.
+        /// </summary>
+        /// <param name="userActivityToUpdate">The UserActivity to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated UserActivity.</returns>
+        public async System.Threading.Tasks.Task<UserActivity> UpdateAsync(UserActivity userActivityToUpdate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PATCH";
+            var updatedEntity = await this.SendAsync<UserActivity>(userActivityToUpdate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(updatedEntity);
+            return updatedEntity;
+        }
+
+		/// <summary>
+        /// Deletes the specified UserActivity.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        public System.Threading.Tasks.Task DeleteAsync()
+        {
+            return this.DeleteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the specified UserActivity.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "DELETE";
+            await this.SendAsync<UserActivity>(null, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>

--- a/src/Microsoft.Graph/Requests/Generated/UserActivityWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/UserActivityWithReferenceRequest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "POST";
             var newEntity = await this.SendAsync<UserActivity>(userActivityToCreate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }
 
@@ -101,7 +100,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "PATCH";
             var updatedEntity = await this.SendAsync<UserActivity>(userActivityToUpdate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }
 

--- a/src/Microsoft.Graph/Requests/Generated/UserWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/UserWithReferenceRequest.cs
@@ -76,7 +76,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "POST";
             var newEntity = await this.SendAsync<User>(userToCreate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(newEntity);
             return newEntity;
         }
 
@@ -101,7 +100,6 @@ namespace Microsoft.Graph
             this.ContentType = "application/json";
             this.Method = "PATCH";
             var updatedEntity = await this.SendAsync<User>(userToUpdate, cancellationToken).ConfigureAwait(false);
-            this.InitializeCollectionProperties(updatedEntity);
             return updatedEntity;
         }
 

--- a/src/Microsoft.Graph/Requests/Generated/UserWithReferenceRequest.cs
+++ b/src/Microsoft.Graph/Requests/Generated/UserWithReferenceRequest.cs
@@ -55,6 +55,76 @@ namespace Microsoft.Graph
             return retrievedEntity;
         }
 
+		/// <summary>
+        /// Creates the specified User using POST.
+        /// </summary>
+        /// <param name="userToCreate">The User to create.</param>
+        /// <returns>The created User.</returns>
+        public System.Threading.Tasks.Task<User> CreateAsync(User userToCreate)
+        {
+            return this.CreateAsync(userToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified User using POST.
+        /// </summary>
+        /// <param name="userToCreate">The User to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created User.</returns>
+        public async System.Threading.Tasks.Task<User> CreateAsync(User userToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "POST";
+            var newEntity = await this.SendAsync<User>(userToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+
+		/// <summary>
+        /// Updates the specified User using PATCH.
+        /// </summary>
+        /// <param name="userToUpdate">The User to update.</param>
+        /// <returns>The updated User.</returns>
+        public System.Threading.Tasks.Task<User> UpdateAsync(User userToUpdate)
+        {
+            return this.UpdateAsync(userToUpdate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Updates the specified User using PATCH.
+        /// </summary>
+        /// <param name="userToUpdate">The User to update.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The updated User.</returns>
+        public async System.Threading.Tasks.Task<User> UpdateAsync(User userToUpdate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PATCH";
+            var updatedEntity = await this.SendAsync<User>(userToUpdate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(updatedEntity);
+            return updatedEntity;
+        }
+
+		/// <summary>
+        /// Deletes the specified User.
+        /// </summary>
+        /// <returns>The task to await.</returns>
+        public System.Threading.Tasks.Task DeleteAsync()
+        {
+            return this.DeleteAsync(CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Deletes the specified User.
+        /// </summary>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The task to await.</returns>
+        public async System.Threading.Tasks.Task DeleteAsync(CancellationToken cancellationToken)
+        {
+            this.Method = "DELETE";
+            await this.SendAsync<User>(null, cancellationToken).ConfigureAwait(false);
+        }
+
         /// <summary>
         /// Adds the specified expand value to the request.
         /// </summary>


### PR DESCRIPTION
Add the following methods to withReferenceRequest generated requests:
- CreateAsync (POST)
- UpdateAsync (PATCH)
- DeleteAsync (DELETE)


This allows you to create, update, and delete references to groups, document lists, etc. Not all methods may be applicable in all scenarios (refer to documentation on which workloads support which verbs).