### PR TITLE
expose HttpProvider internal constructor with param HttpMessageHandle…

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Graph
         /// <param name="httpMessageHandler">An HTTP message handler to pass to the <see cref="HttpClient"/> for sending requests.</param>
         /// <param name="disposeHandler">Whether or not to dispose the client handler on Dispose().</param>
         /// <param name="serializer">A serializer for serializing and deserializing JSON objects.</param>
-        internal HttpProvider(HttpMessageHandler httpMessageHandler, bool disposeHandler, ISerializer serializer)
+        public HttpProvider(HttpMessageHandler httpMessageHandler, bool disposeHandler, ISerializer serializer)
         {
             this.disposeHandler = disposeHandler;
             this.httpMessageHandler = httpMessageHandler ?? new HttpClientHandler { AllowAutoRedirect = false };

--- a/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
@@ -83,6 +83,20 @@ namespace Microsoft.Graph.Core.Test.Requests
         }
 
         [TestMethod]
+        public void HttpProvider_HttpMessageHandlerConstructor()
+        {
+            using (var testhttpMessageHandler = new TestHttpMessageHandler())
+            using (var httpProvider = new HttpProvider(testhttpMessageHandler, true, null))
+            {
+                Assert.IsNotNull(httpProvider.httpMessageHandler, "HttpMessageHandler not initialized");
+                Assert.AreEqual(httpProvider.httpMessageHandler, testhttpMessageHandler, "Unexpected message handler set.");
+                Assert.IsTrue(httpProvider.disposeHandler, "Dispose Handler set to false");
+                Assert.IsInstanceOfType(httpProvider.Serializer, typeof(Serializer), "Unexpected serializer initialized.");
+            }
+        }
+
+
+        [TestMethod]
         [ExpectedException(typeof(ServiceException))]
         public async Task OverallTimeout_RequestAlreadySent()
         {

--- a/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
@@ -85,11 +85,11 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void HttpProvider_HttpMessageHandlerConstructor()
         {
-            using (var testhttpMessageHandler = new TestHttpMessageHandler())
-            using (var httpProvider = new HttpProvider(testhttpMessageHandler, true, null))
+           
+            using (var httpProvider = new HttpProvider(this.testHttpMessageHandler, true, null))
             {
                 Assert.IsNotNull(httpProvider.httpMessageHandler, "HttpMessageHandler not initialized");
-                Assert.AreEqual(httpProvider.httpMessageHandler, testhttpMessageHandler, "Unexpected message handler set.");
+                Assert.AreEqual(httpProvider.httpMessageHandler, this.testHttpMessageHandler, "Unexpected message handler set.");
                 Assert.IsTrue(httpProvider.disposeHandler, "Dispose Handler set to false");
                 Assert.IsInstanceOfType(httpProvider.Serializer, typeof(Serializer), "Unexpected serializer initialized.");
             }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
@@ -82,11 +82,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
         [Fact]
         public void HttpProvider_HttpMessageHandlerConstructor() {
-            using (var testhttpMessageHandler = new TestHttpMessageHandler())
-            using (var httpProvider = new HttpProvider(testhttpMessageHandler, false, null))
+           
+            using (var httpProvider = new HttpProvider(this.testHttpMessageHandler, false, null))
             {
                 Assert.NotNull(httpProvider.httpMessageHandler);
-                Assert.Equal(httpProvider.httpMessageHandler, testhttpMessageHandler);
+                Assert.Equal(httpProvider.httpMessageHandler, this.testHttpMessageHandler);
                 Assert.False(httpProvider.disposeHandler);
                 Assert.IsType(typeof(Serializer), httpProvider.Serializer);
             }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
@@ -81,6 +81,18 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
+        public void HttpProvider_HttpMessageHandlerConstructor() {
+            using (var testhttpMessageHandler = new TestHttpMessageHandler())
+            using (var httpProvider = new HttpProvider(testhttpMessageHandler, false, null))
+            {
+                Assert.NotNull(httpProvider.httpMessageHandler);
+                Assert.Equal(httpProvider.httpMessageHandler, testhttpMessageHandler);
+                Assert.False(httpProvider.disposeHandler);
+                Assert.IsType(typeof(Serializer), httpProvider.Serializer);
+            }
+        }
+
+        [Fact]
         public async Task OverallTimeout_RequestAlreadySent()
         {
             using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost"))


### PR DESCRIPTION
Fixes # 285

Expose HttpProvider internal constructor method with param HttpMessageHandler to be public. 


