### PR TITLE
Updated base complex types with an ODataType property. 

### DIFF
--- a/src/Microsoft.Graph/Models/Generated/AlertTrigger.cs
+++ b/src/Microsoft.Graph/Models/Generated/AlertTrigger.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AlertTrigger
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AllDevicesAssignmentTarget.cs
+++ b/src/Microsoft.Graph/Models/Generated/AllDevicesAssignmentTarget.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class AllDevicesAssignmentTarget : DeviceAndAppManagementAssignmentTarget
     {
-    
+        public AllDevicesAssignmentTarget()
+        {
+            this.ODataType = "microsoft.graph.allDevicesAssignmentTarget";
+        }
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AllLicensedUsersAssignmentTarget.cs
+++ b/src/Microsoft.Graph/Models/Generated/AllLicensedUsersAssignmentTarget.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class AllLicensedUsersAssignmentTarget : DeviceAndAppManagementAssignmentTarget
     {
-    
+        public AllLicensedUsersAssignmentTarget()
+        {
+            this.ODataType = "microsoft.graph.allLicensedUsersAssignmentTarget";
+        }
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AlternativeSecurityId.cs
+++ b/src/Microsoft.Graph/Models/Generated/AlternativeSecurityId.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AlternativeSecurityId
     {
-    
+
         /// <summary>
         /// Gets or sets type.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AndroidMinimumOperatingSystem.cs
+++ b/src/Microsoft.Graph/Models/Generated/AndroidMinimumOperatingSystem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AndroidMinimumOperatingSystem
     {
-    
+
         /// <summary>
         /// Gets or sets v4_0.
         /// Version 4.0 or later.
@@ -83,6 +83,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AndroidMobileAppIdentifier.cs
+++ b/src/Microsoft.Graph/Models/Generated/AndroidMobileAppIdentifier.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class AndroidMobileAppIdentifier : MobileAppIdentifier
     {
-    
+        public AndroidMobileAppIdentifier()
+        {
+            this.ODataType = "microsoft.graph.androidMobileAppIdentifier";
+        }
         /// <summary>
         /// Gets or sets packageId.
         /// The identifier for an app, as specified in the play store.

--- a/src/Microsoft.Graph/Models/Generated/AppConfigurationSettingItem.cs
+++ b/src/Microsoft.Graph/Models/Generated/AppConfigurationSettingItem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AppConfigurationSettingItem
     {
-    
+
         /// <summary>
         /// Gets or sets appConfigKey.
         /// app configuration key.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AppListItem.cs
+++ b/src/Microsoft.Graph/Models/Generated/AppListItem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AppListItem
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// The application name
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AssignedLicense.cs
+++ b/src/Microsoft.Graph/Models/Generated/AssignedLicense.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AssignedLicense
     {
-    
+
         /// <summary>
         /// Gets or sets disabledPlans.
         /// A collection of the unique identifiers for plans that have been disabled.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AssignedPlan.cs
+++ b/src/Microsoft.Graph/Models/Generated/AssignedPlan.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AssignedPlan
     {
-    
+
         /// <summary>
         /// Gets or sets assignedDateTime.
         /// The date and time at which the plan was assigned; for example: 2013-01-02T19:32:30Z. The Timestamp type represents date and time information using ISO 8601 format and is always in UTC time. For example, midnight UTC on Jan 1, 2014 would look like this: '2014-01-01T00:00:00Z'
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Attendee.cs
+++ b/src/Microsoft.Graph/Models/Generated/Attendee.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class Attendee : AttendeeBase
     {
-    
+
         /// <summary>
         /// Gets or sets status.
         /// The attendee's response (none, accepted, declined, etc.) for the event and date-time that the response was sent.

--- a/src/Microsoft.Graph/Models/Generated/AttendeeAvailability.cs
+++ b/src/Microsoft.Graph/Models/Generated/AttendeeAvailability.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AttendeeAvailability
     {
-    
+
         /// <summary>
         /// Gets or sets attendee.
         /// The type of attendee - whether it's a person or a resource, and whether required or optional if it's a person.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AttendeeBase.cs
+++ b/src/Microsoft.Graph/Models/Generated/AttendeeBase.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class AttendeeBase : Recipient
     {
-    
+
         /// <summary>
         /// Gets or sets type.
         /// The type of attendee. Possible values are: required, optional, resource. Currently if the attendee is a person, findMeetingTimes always considers the person is of the Required type.

--- a/src/Microsoft.Graph/Models/Generated/Audio.cs
+++ b/src/Microsoft.Graph/Models/Generated/Audio.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Audio
     {
-    
+
         /// <summary>
         /// Gets or sets album.
         /// The title of the album for this audio file.
@@ -139,6 +139,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AutomaticRepliesMailTips.cs
+++ b/src/Microsoft.Graph/Models/Generated/AutomaticRepliesMailTips.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AutomaticRepliesMailTips
     {
-    
+
         /// <summary>
         /// Gets or sets message.
         /// </summary>
@@ -51,6 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/AutomaticRepliesSetting.cs
+++ b/src/Microsoft.Graph/Models/Generated/AutomaticRepliesSetting.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class AutomaticRepliesSetting
     {
-    
+
         /// <summary>
         /// Gets or sets status.
         /// Configurations status for automatic replies. Possible values are: disabled, alwaysEnabled, scheduled.
@@ -69,6 +69,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/BitLockerRemovableDrivePolicy.cs
+++ b/src/Microsoft.Graph/Models/Generated/BitLockerRemovableDrivePolicy.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class BitLockerRemovableDrivePolicy
     {
-    
+
         /// <summary>
         /// Gets or sets encryptionMethod.
         /// Select the encryption method for removable  drives. Possible values are: aesCbc128, aesCbc256, xtsAes128, xtsAes256.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/BooleanColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/BooleanColumn.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class BooleanColumn
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/CalculatedColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/CalculatedColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class CalculatedColumn
     {
-    
+
         /// <summary>
         /// Gets or sets format.
         /// For dateTime output types, the format of the value. Must be one of dateOnly or dateTime.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ChoiceColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/ChoiceColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ChoiceColumn
     {
-    
+
         /// <summary>
         /// Gets or sets allowTextEntry.
         /// If true, allows custom values that aren't in the configured choices.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/CloudAppSecurityState.cs
+++ b/src/Microsoft.Graph/Models/Generated/CloudAppSecurityState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class CloudAppSecurityState
     {
-    
+
         /// <summary>
         /// Gets or sets destinationServiceIp.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ComplexExtensionValue.cs
+++ b/src/Microsoft.Graph/Models/Generated/ComplexExtensionValue.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ComplexExtensionValue
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ConfigurationManagerClientEnabledFeatures.cs
+++ b/src/Microsoft.Graph/Models/Generated/ConfigurationManagerClientEnabledFeatures.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ConfigurationManagerClientEnabledFeatures
     {
-    
+
         /// <summary>
         /// Gets or sets inventory.
         /// Whether inventory is managed by Intune
@@ -69,6 +69,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ContentTypeInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/ContentTypeInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ContentTypeInfo
     {
-    
+
         /// <summary>
         /// Gets or sets id.
         /// The id of the content type.
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ContentTypeOrder.cs
+++ b/src/Microsoft.Graph/Models/Generated/ContentTypeOrder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ContentTypeOrder
     {
-    
+
         /// <summary>
         /// Gets or sets default.
         /// Whether this is the default Content Type
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/CurrencyColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/CurrencyColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class CurrencyColumn
     {
-    
+
         /// <summary>
         /// Gets or sets locale.
         /// Specifies the locale from which to infer the currency symbol.
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/CustomTimeZone.cs
+++ b/src/Microsoft.Graph/Models/Generated/CustomTimeZone.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class CustomTimeZone : TimeZoneBase
     {
-    
+
         /// <summary>
         /// Gets or sets bias.
         /// The time offset of the time zone from Coordinated Universal Time (UTC). This value is in minutes. Time zones that are ahead of UTC have a positive offset; time zones that are behind UTC have a negative offset.

--- a/src/Microsoft.Graph/Models/Generated/DateTimeColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/DateTimeColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DateTimeColumn
     {
-    
+
         /// <summary>
         /// Gets or sets displayAs.
         /// How the value should be presented in the UX. Must be one of default, friendly, or standard. See below for more details. If unspecified, treated as default.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DateTimeTimeZone.cs
+++ b/src/Microsoft.Graph/Models/Generated/DateTimeTimeZone.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DateTimeTimeZone
     {
-    
+
         /// <summary>
         /// Gets or sets dateTime.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DaylightTimeZoneOffset.cs
+++ b/src/Microsoft.Graph/Models/Generated/DaylightTimeZoneOffset.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class DaylightTimeZoneOffset : StandardTimeZoneOffset
     {
-    
+
         /// <summary>
         /// Gets or sets daylightBias.
         /// The time offset from Coordinated Universal Time (UTC) for daylight saving time. This value is in minutes.

--- a/src/Microsoft.Graph/Models/Generated/DefaultColumnValue.cs
+++ b/src/Microsoft.Graph/Models/Generated/DefaultColumnValue.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DefaultColumnValue
     {
-    
+
         /// <summary>
         /// Gets or sets formula.
         /// The formula used to compute the default value for this column.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DefenderDetectedMalwareActions.cs
+++ b/src/Microsoft.Graph/Models/Generated/DefenderDetectedMalwareActions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DefenderDetectedMalwareActions
     {
-    
+
         /// <summary>
         /// Gets or sets lowSeverity.
         /// Indicates a Defender action to take for low severity Malware threat detected. Possible values are: deviceDefault, clean, quarantine, remove, allow, userDefined, block.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeleteUserFromSharedAppleDeviceActionResult.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeleteUserFromSharedAppleDeviceActionResult.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class DeleteUserFromSharedAppleDeviceActionResult : DeviceActionResult
     {
-    
+
         /// <summary>
         /// Gets or sets userPrincipalName.
         /// User principal name of the user to be deleted

--- a/src/Microsoft.Graph/Models/Generated/Deleted.cs
+++ b/src/Microsoft.Graph/Models/Generated/Deleted.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Deleted
     {
-    
+
         /// <summary>
         /// Gets or sets state.
         /// Represents the state of the deleted item.
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceActionResult.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceActionResult.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceActionResult
     {
-    
+
         /// <summary>
         /// Gets or sets actionName.
         /// Action name
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceAndAppManagementAssignmentTarget.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceAndAppManagementAssignmentTarget.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class DeviceAndAppManagementAssignmentTarget
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceCompliancePolicySettingState.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceCompliancePolicySettingState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceCompliancePolicySettingState
     {
-    
+
         /// <summary>
         /// Gets or sets setting.
         /// The setting that is being reported
@@ -111,6 +111,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceConfigurationSettingState.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceConfigurationSettingState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceConfigurationSettingState
     {
-    
+
         /// <summary>
         /// Gets or sets setting.
         /// The setting that is being reported
@@ -111,6 +111,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceEnrollmentPlatformRestriction.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceEnrollmentPlatformRestriction.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceEnrollmentPlatformRestriction
     {
-    
+
         /// <summary>
         /// Gets or sets platformBlocked.
         /// Block the platform from enrolling
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceExchangeAccessStateSummary.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceExchangeAccessStateSummary.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceExchangeAccessStateSummary
     {
-    
+
         /// <summary>
         /// Gets or sets allowedDeviceCount.
         /// Total count of devices with Exchange Access State: Allowed.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceGeoLocation.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceGeoLocation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceGeoLocation
     {
-    
+
         /// <summary>
         /// Gets or sets lastCollectedDateTime.
         /// Time at which location was recorded, relative to UTC
@@ -83,6 +83,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceHealthAttestationState.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceHealthAttestationState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceHealthAttestationState
     {
-    
+
         /// <summary>
         /// Gets or sets lastUpdateDateTime.
         /// The Timestamp of the last update.
@@ -251,6 +251,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceManagementSettings.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceManagementSettings.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceManagementSettings
     {
-    
+
         /// <summary>
         /// Gets or sets deviceComplianceCheckinThresholdDays.
         /// The number of days a device is allowed to go without checking in to remain compliant. Valid values 0 to 120
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DeviceOperatingSystemSummary.cs
+++ b/src/Microsoft.Graph/Models/Generated/DeviceOperatingSystemSummary.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DeviceOperatingSystemSummary
     {
-    
+
         /// <summary>
         /// Gets or sets androidCount.
         /// Number of android device count.
@@ -69,6 +69,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Diagnostic.cs
+++ b/src/Microsoft.Graph/Models/Generated/Diagnostic.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Diagnostic
     {
-    
+
         /// <summary>
         /// Gets or sets message.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DomainState.cs
+++ b/src/Microsoft.Graph/Models/Generated/DomainState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DomainState
     {
-    
+
         /// <summary>
         /// Gets or sets status.
         /// Current status of the operation.  Scheduled - Operation has been scheduled but has not started.  InProgress - Task has started and is in progress.  Failed - Operation has failed.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DriveItemUploadableProperties.cs
+++ b/src/Microsoft.Graph/Models/Generated/DriveItemUploadableProperties.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DriveItemUploadableProperties
     {
-    
+
         /// <summary>
         /// Gets or sets description.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/DriveRecipient.cs
+++ b/src/Microsoft.Graph/Models/Generated/DriveRecipient.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class DriveRecipient
     {
-    
+
         /// <summary>
         /// Gets or sets alias.
         /// The alias of the domain object, for cases where an email address is unavailable (e.g. security groups).
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/EdgeSearchEngine.cs
+++ b/src/Microsoft.Graph/Models/Generated/EdgeSearchEngine.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class EdgeSearchEngine : EdgeSearchEngineBase
     {
-    
+        public EdgeSearchEngine()
+        {
+            this.ODataType = "microsoft.graph.edgeSearchEngine";
+        }
         /// <summary>
         /// Gets or sets edgeSearchEngineType.
         /// Allows IT admins to set a predefined default search engine for MDM-Controlled devices. Possible values are: default, bing.

--- a/src/Microsoft.Graph/Models/Generated/EdgeSearchEngineBase.cs
+++ b/src/Microsoft.Graph/Models/Generated/EdgeSearchEngineBase.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class EdgeSearchEngineBase
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/EdgeSearchEngineCustom.cs
+++ b/src/Microsoft.Graph/Models/Generated/EdgeSearchEngineCustom.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class EdgeSearchEngineCustom : EdgeSearchEngineBase
     {
-    
+        public EdgeSearchEngineCustom()
+        {
+            this.ODataType = "microsoft.graph.edgeSearchEngineCustom";
+        }
         /// <summary>
         /// Gets or sets edgeSearchEngineOpenSearchXmlUrl.
         /// Points to a https link containing the OpenSearch xml file that contains, at minimum, the short name and the URL to the search Engine.

--- a/src/Microsoft.Graph/Models/Generated/EducationRelatedContact.cs
+++ b/src/Microsoft.Graph/Models/Generated/EducationRelatedContact.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class EducationRelatedContact
     {
-    
+
         /// <summary>
         /// Gets or sets id.
         /// </summary>
@@ -63,6 +63,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/EducationStudent.cs
+++ b/src/Microsoft.Graph/Models/Generated/EducationStudent.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class EducationStudent
     {
-    
+
         /// <summary>
         /// Gets or sets graduationYear.
         /// Year the student is graduating from the school.
@@ -69,6 +69,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/EducationTeacher.cs
+++ b/src/Microsoft.Graph/Models/Generated/EducationTeacher.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class EducationTeacher
     {
-    
+
         /// <summary>
         /// Gets or sets teacherNumber.
         /// Teacher number.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/EducationTerm.cs
+++ b/src/Microsoft.Graph/Models/Generated/EducationTerm.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class EducationTerm
     {
-    
+
         /// <summary>
         /// Gets or sets externalId.
         /// ID of term in the syncing system.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/EmailAddress.cs
+++ b/src/Microsoft.Graph/Models/Generated/EmailAddress.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class EmailAddress
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// The display name of the person or entity.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ExclusionGroupAssignmentTarget.cs
+++ b/src/Microsoft.Graph/Models/Generated/ExclusionGroupAssignmentTarget.cs
@@ -20,6 +20,6 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class ExclusionGroupAssignmentTarget : GroupAssignmentTarget
     {
-    
+
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ExtensionSchemaProperty.cs
+++ b/src/Microsoft.Graph/Models/Generated/ExtensionSchemaProperty.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ExtensionSchemaProperty
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// The name of the strongly-typed property defined as part of a schema extension.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ExternalLink.cs
+++ b/src/Microsoft.Graph/Models/Generated/ExternalLink.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ExternalLink
     {
-    
+
         /// <summary>
         /// Gets or sets href.
         /// The url of the link.
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/File.cs
+++ b/src/Microsoft.Graph/Models/Generated/File.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class File
     {
-    
+
         /// <summary>
         /// Gets or sets hashes.
         /// Hashes of the file's binary content, if available. Read-only.
@@ -47,6 +47,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/FileEncryptionInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/FileEncryptionInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class FileEncryptionInfo
     {
-    
+
         /// <summary>
         /// Gets or sets encryptionKey.
         /// The key used to encrypt the file content.
@@ -76,6 +76,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/FileHash.cs
+++ b/src/Microsoft.Graph/Models/Generated/FileHash.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class FileHash
     {
-    
+
         /// <summary>
         /// Gets or sets hashType.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/FileSecurityState.cs
+++ b/src/Microsoft.Graph/Models/Generated/FileSecurityState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class FileSecurityState
     {
-    
+
         /// <summary>
         /// Gets or sets fileHash.
         /// </summary>
@@ -51,6 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/FileSystemInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/FileSystemInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class FileSystemInfo
     {
-    
+
         /// <summary>
         /// Gets or sets createdDateTime.
         /// The UTC date and time the file was created on a client.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Folder.cs
+++ b/src/Microsoft.Graph/Models/Generated/Folder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Folder
     {
-    
+
         /// <summary>
         /// Gets or sets childCount.
         /// Number of children contained immediately within this container.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/FolderView.cs
+++ b/src/Microsoft.Graph/Models/Generated/FolderView.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class FolderView
     {
-    
+
         /// <summary>
         /// Gets or sets sortBy.
         /// The method by which the folder should be sorted.
@@ -47,6 +47,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/FollowupFlag.cs
+++ b/src/Microsoft.Graph/Models/Generated/FollowupFlag.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class FollowupFlag
     {
-    
+
         /// <summary>
         /// Gets or sets completedDateTime.
         /// The date and time that the follow-up was finished.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/GeoCoordinates.cs
+++ b/src/Microsoft.Graph/Models/Generated/GeoCoordinates.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class GeoCoordinates
     {
-    
+
         /// <summary>
         /// Gets or sets altitude.
         /// Optional. The altitude (height), in feet,  above sea level for the item. Read-only.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/GroupAssignmentTarget.cs
+++ b/src/Microsoft.Graph/Models/Generated/GroupAssignmentTarget.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class GroupAssignmentTarget : DeviceAndAppManagementAssignmentTarget
     {
-    
+        public GroupAssignmentTarget()
+        {
+            this.ODataType = "microsoft.graph.groupAssignmentTarget";
+        }
         /// <summary>
         /// Gets or sets groupId.
         /// The group Id that is the target of the assignment.

--- a/src/Microsoft.Graph/Models/Generated/Hashes.cs
+++ b/src/Microsoft.Graph/Models/Generated/Hashes.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Hashes
     {
-    
+
         /// <summary>
         /// Gets or sets crc32Hash.
         /// The CRC32 value of the file (if available). Read-only.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/HostSecurityState.cs
+++ b/src/Microsoft.Graph/Models/Generated/HostSecurityState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class HostSecurityState
     {
-    
+
         /// <summary>
         /// Gets or sets fqdn.
         /// </summary>
@@ -81,6 +81,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IPv4Range.cs
+++ b/src/Microsoft.Graph/Models/Generated/IPv4Range.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class IPv4Range : IpRange
     {
-    
+
         /// <summary>
         /// Gets or sets lowerAddress.
         /// Lower IP Address

--- a/src/Microsoft.Graph/Models/Generated/IPv6Range.cs
+++ b/src/Microsoft.Graph/Models/Generated/IPv6Range.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class IPv6Range : IpRange
     {
-    
+
         /// <summary>
         /// Gets or sets lowerAddress.
         /// Lower IP Address

--- a/src/Microsoft.Graph/Models/Generated/Identity.cs
+++ b/src/Microsoft.Graph/Models/Generated/Identity.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Identity
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// The identity's display name. Note that this may not always be available or up to date. For example, if a user changes their display name, the API may show the new value in a future response, but the items associated with the user won't show up as having changed when using delta.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IdentitySet.cs
+++ b/src/Microsoft.Graph/Models/Generated/IdentitySet.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class IdentitySet
     {
-    
+
         /// <summary>
         /// Gets or sets application.
         /// Optional. The application associated with this action.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Image.cs
+++ b/src/Microsoft.Graph/Models/Generated/Image.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Image
     {
-    
+
         /// <summary>
         /// Gets or sets height.
         /// Optional. Height of the image, in pixels. Read-only.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ImageInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/ImageInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ImageInfo
     {
-    
+
         /// <summary>
         /// Gets or sets iconUrl.
         /// Optional; URI that points to an icon which represents the application used to generate the activity
@@ -54,6 +54,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/InsightIdentity.cs
+++ b/src/Microsoft.Graph/Models/Generated/InsightIdentity.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class InsightIdentity
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/InternetMessageHeader.cs
+++ b/src/Microsoft.Graph/Models/Generated/InternetMessageHeader.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class InternetMessageHeader
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// Represents the key in a key-value pair.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IntuneBrand.cs
+++ b/src/Microsoft.Graph/Models/Generated/IntuneBrand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class IntuneBrand
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// Company/organization name that is displayed to end users.
@@ -125,6 +125,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/InvitedUserMessageInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/InvitedUserMessageInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class InvitedUserMessageInfo
     {
-    
+
         /// <summary>
         /// Gets or sets ccRecipients.
         /// Additional recipients the invitation message should be sent to. Currently only 1 additional recipient is supported.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IosDeviceType.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosDeviceType.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class IosDeviceType
     {
-    
+
         /// <summary>
         /// Gets or sets iPad.
         /// Whether the app should run on iPads.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IosHomeScreenApp.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosHomeScreenApp.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class IosHomeScreenApp : IosHomeScreenItem
     {
-    
+        public IosHomeScreenApp()
+        {
+            this.ODataType = "microsoft.graph.iosHomeScreenApp";
+        }
         /// <summary>
         /// Gets or sets bundleID.
         /// BundleID of app

--- a/src/Microsoft.Graph/Models/Generated/IosHomeScreenFolder.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosHomeScreenFolder.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class IosHomeScreenFolder : IosHomeScreenItem
     {
-    
+        public IosHomeScreenFolder()
+        {
+            this.ODataType = "microsoft.graph.iosHomeScreenFolder";
+        }
         /// <summary>
         /// Gets or sets pages.
         /// Pages of Home Screen Layout Icons which must be Application Type. This collection can contain a maximum of 500 elements.

--- a/src/Microsoft.Graph/Models/Generated/IosHomeScreenFolderPage.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosHomeScreenFolderPage.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class IosHomeScreenFolderPage
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// Name of the folder page
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IosHomeScreenItem.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosHomeScreenItem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class IosHomeScreenItem
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// Name of the app
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IosHomeScreenPage.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosHomeScreenPage.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class IosHomeScreenPage
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// Name of the page
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IosLobAppAssignmentSettings.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosLobAppAssignmentSettings.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class IosLobAppAssignmentSettings : MobileAppAssignmentSettings
     {
-    
+        public IosLobAppAssignmentSettings()
+        {
+            this.ODataType = "microsoft.graph.iosLobAppAssignmentSettings";
+        }
         /// <summary>
         /// Gets or sets vpnConfigurationId.
         /// The VPN Configuration Id to apply for this app.

--- a/src/Microsoft.Graph/Models/Generated/IosMinimumOperatingSystem.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosMinimumOperatingSystem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class IosMinimumOperatingSystem
     {
-    
+
         /// <summary>
         /// Gets or sets v8_0.
         /// Version 8.0 or later.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IosMobileAppIdentifier.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosMobileAppIdentifier.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class IosMobileAppIdentifier : MobileAppIdentifier
     {
-    
+        public IosMobileAppIdentifier()
+        {
+            this.ODataType = "microsoft.graph.iosMobileAppIdentifier";
+        }
         /// <summary>
         /// Gets or sets bundleId.
         /// The identifier for an app, as specified in the app store.

--- a/src/Microsoft.Graph/Models/Generated/IosNetworkUsageRule.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosNetworkUsageRule.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class IosNetworkUsageRule
     {
-    
+
         /// <summary>
         /// Gets or sets managedApps.
         /// Information about the managed apps that this rule is going to apply to. This collection can contain a maximum of 500 elements.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IosNotificationSettings.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosNotificationSettings.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class IosNotificationSettings
     {
-    
+
         /// <summary>
         /// Gets or sets bundleID.
         /// Bundle id of app to which to apply these notification settings.
@@ -90,6 +90,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/IosStoreAppAssignmentSettings.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosStoreAppAssignmentSettings.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class IosStoreAppAssignmentSettings : MobileAppAssignmentSettings
     {
-    
+        public IosStoreAppAssignmentSettings()
+        {
+            this.ODataType = "microsoft.graph.iosStoreAppAssignmentSettings";
+        }
         /// <summary>
         /// Gets or sets vpnConfigurationId.
         /// The VPN Configuration Id to apply for this app.

--- a/src/Microsoft.Graph/Models/Generated/IosVppAppAssignmentSettings.cs
+++ b/src/Microsoft.Graph/Models/Generated/IosVppAppAssignmentSettings.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class IosVppAppAssignmentSettings : MobileAppAssignmentSettings
     {
-    
+        public IosVppAppAssignmentSettings()
+        {
+            this.ODataType = "microsoft.graph.iosVppAppAssignmentSettings";
+        }
         /// <summary>
         /// Gets or sets useDeviceLicensing.
         /// Whether or not to use device licensing.

--- a/src/Microsoft.Graph/Models/Generated/IpRange.cs
+++ b/src/Microsoft.Graph/Models/Generated/IpRange.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class IpRange
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ItemBody.cs
+++ b/src/Microsoft.Graph/Models/Generated/ItemBody.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ItemBody
     {
-    
+
         /// <summary>
         /// Gets or sets contentType.
         /// The type of the content. Possible values are Text and HTML.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ItemReference.cs
+++ b/src/Microsoft.Graph/Models/Generated/ItemReference.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ItemReference
     {
-    
+
         /// <summary>
         /// Gets or sets driveId.
         /// Unique identifier of the drive instance that contains the item. Read-only.
@@ -76,6 +76,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/KeyValuePair.cs
+++ b/src/Microsoft.Graph/Models/Generated/KeyValuePair.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class KeyValuePair
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// Name for this key-value pair
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/LicenseUnitsDetail.cs
+++ b/src/Microsoft.Graph/Models/Generated/LicenseUnitsDetail.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class LicenseUnitsDetail
     {
-    
+
         /// <summary>
         /// Gets or sets enabled.
         /// The number of units that are enabled.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ListInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/ListInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ListInfo
     {
-    
+
         /// <summary>
         /// Gets or sets contentTypesEnabled.
         /// If true, indicates that content types are enabled for this list.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/LocaleInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/LocaleInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class LocaleInfo
     {
-    
+
         /// <summary>
         /// Gets or sets locale.
         /// A locale representation for the user, which includes the user's preferred language and country/region. For example, "en-us". The language component follows 2-letter codes as defined in ISO 639-1, and the country component follows 2-letter codes as defined in ISO 3166-1 alpha-2.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/LocateDeviceActionResult.cs
+++ b/src/Microsoft.Graph/Models/Generated/LocateDeviceActionResult.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class LocateDeviceActionResult : DeviceActionResult
     {
-    
+
         /// <summary>
         /// Gets or sets deviceLocation.
         /// device location

--- a/src/Microsoft.Graph/Models/Generated/Location.cs
+++ b/src/Microsoft.Graph/Models/Generated/Location.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Location
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// The name associated with the location.
@@ -83,6 +83,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/LocationConstraint.cs
+++ b/src/Microsoft.Graph/Models/Generated/LocationConstraint.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class LocationConstraint
     {
-    
+
         /// <summary>
         /// Gets or sets isRequired.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/LocationConstraintItem.cs
+++ b/src/Microsoft.Graph/Models/Generated/LocationConstraintItem.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class LocationConstraintItem : Location
     {
-    
+
         /// <summary>
         /// Gets or sets resolveAvailability.
         /// If set to true and the specified resource is busy, findMeetingTimes looks for another resource that is free. If set to false and the specified resource is busy, findMeetingTimes returns the resource best ranked in the user's cache without checking if it's free. Default is true.

--- a/src/Microsoft.Graph/Models/Generated/LookupColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/LookupColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class LookupColumn
     {
-    
+
         /// <summary>
         /// Gets or sets allowMultipleValues.
         /// Indicates whether multiple values can be selected from the source.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MailTips.cs
+++ b/src/Microsoft.Graph/Models/Generated/MailTips.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MailTips
     {
-    
+
         /// <summary>
         /// Gets or sets emailAddress.
         /// </summary>
@@ -99,6 +99,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MailTipsError.cs
+++ b/src/Microsoft.Graph/Models/Generated/MailTipsError.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MailTipsError
     {
-    
+
         /// <summary>
         /// Gets or sets message.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MailboxSettings.cs
+++ b/src/Microsoft.Graph/Models/Generated/MailboxSettings.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MailboxSettings
     {
-    
+
         /// <summary>
         /// Gets or sets automaticRepliesSetting.
         /// Configuration settings to automatically notify the sender of an incoming email with a message from the signed-in user.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MalwareState.cs
+++ b/src/Microsoft.Graph/Models/Generated/MalwareState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MalwareState
     {
-    
+
         /// <summary>
         /// Gets or sets category.
         /// </summary>
@@ -57,6 +57,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ManagedAppDiagnosticStatus.cs
+++ b/src/Microsoft.Graph/Models/Generated/ManagedAppDiagnosticStatus.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ManagedAppDiagnosticStatus
     {
-    
+
         /// <summary>
         /// Gets or sets validationName.
         /// The validation friendly name
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ManagedAppPolicyDeploymentSummaryPerApp.cs
+++ b/src/Microsoft.Graph/Models/Generated/ManagedAppPolicyDeploymentSummaryPerApp.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ManagedAppPolicyDeploymentSummaryPerApp
     {
-    
+
         /// <summary>
         /// Gets or sets mobileAppIdentifier.
         /// Deployment of an app.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingAustralia.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingAustralia.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingAustralia
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for Australia. Possible values are: allAllowed, allBlocked, general, parentalGuidance, mature, agesAbove15, agesAbove18.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingCanada.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingCanada.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingCanada
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for Canada. Possible values are: allAllowed, allBlocked, general, parentalGuidance, agesAbove14, agesAbove18, restricted.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingFrance.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingFrance.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingFrance
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for France. Possible values are: allAllowed, allBlocked, agesAbove10, agesAbove12, agesAbove16, agesAbove18.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingGermany.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingGermany.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingGermany
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for Germany. Possible values are: allAllowed, allBlocked, general, agesAbove6, agesAbove12, agesAbove16, adults.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingIreland.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingIreland.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingIreland
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for Ireland. Possible values are: allAllowed, allBlocked, general, parentalGuidance, agesAbove12, agesAbove15, agesAbove16, adults.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingJapan.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingJapan.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingJapan
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for Japan. Possible values are: allAllowed, allBlocked, general, parentalGuidance, agesAbove15, agesAbove18.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingNewZealand.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingNewZealand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingNewZealand
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for New Zealand. Possible values are: allAllowed, allBlocked, general, parentalGuidance, mature, agesAbove13, agesAbove15, agesAbove16, agesAbove18, restricted, agesAbove16Restricted.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingUnitedKingdom.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingUnitedKingdom.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingUnitedKingdom
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for United Kingdom. Possible values are: allAllowed, allBlocked, general, universalChildren, parentalGuidance, agesAbove12Video, agesAbove12Cinema, agesAbove15, adults.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MediaContentRatingUnitedStates.cs
+++ b/src/Microsoft.Graph/Models/Generated/MediaContentRatingUnitedStates.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MediaContentRatingUnitedStates
     {
-    
+
         /// <summary>
         /// Gets or sets movieRating.
         /// Movies rating selected for United States. Possible values are: allAllowed, allBlocked, general, parentalGuidance, parentalGuidance13, restricted, adults.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MeetingTimeSuggestion.cs
+++ b/src/Microsoft.Graph/Models/Generated/MeetingTimeSuggestion.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MeetingTimeSuggestion
     {
-    
+
         /// <summary>
         /// Gets or sets meetingTimeSlot.
         /// A time period suggested for the meeting.
@@ -69,6 +69,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MeetingTimeSuggestionsResult.cs
+++ b/src/Microsoft.Graph/Models/Generated/MeetingTimeSuggestionsResult.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MeetingTimeSuggestionsResult
     {
-    
+
         /// <summary>
         /// Gets or sets meetingTimeSuggestions.
         /// An array of meeting suggestions.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MessageRuleActions.cs
+++ b/src/Microsoft.Graph/Models/Generated/MessageRuleActions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MessageRuleActions
     {
-    
+
         /// <summary>
         /// Gets or sets moveToFolder.
         /// The ID of the folder that a message will be moved to.
@@ -104,6 +104,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MessageRulePredicates.cs
+++ b/src/Microsoft.Graph/Models/Generated/MessageRulePredicates.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MessageRulePredicates
     {
-    
+
         /// <summary>
         /// Gets or sets categories.
         /// Represents the categories that an incoming message should be labeled with in order for the condition or exception to apply.
@@ -237,6 +237,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MicrosoftStoreForBusinessAppAssignmentSettings.cs
+++ b/src/Microsoft.Graph/Models/Generated/MicrosoftStoreForBusinessAppAssignmentSettings.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class MicrosoftStoreForBusinessAppAssignmentSettings : MobileAppAssignmentSettings
     {
-    
+        public MicrosoftStoreForBusinessAppAssignmentSettings()
+        {
+            this.ODataType = "microsoft.graph.microsoftStoreForBusinessAppAssignmentSettings";
+        }
         /// <summary>
         /// Gets or sets useDeviceContext.
         /// Whether or not to use device execution context for Microsoft Store for Business mobile app.

--- a/src/Microsoft.Graph/Models/Generated/MimeContent.cs
+++ b/src/Microsoft.Graph/Models/Generated/MimeContent.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class MimeContent
     {
-    
+
         /// <summary>
         /// Gets or sets type.
         /// Indicates the content mime type.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MobileAppAssignmentSettings.cs
+++ b/src/Microsoft.Graph/Models/Generated/MobileAppAssignmentSettings.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class MobileAppAssignmentSettings
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/MobileAppIdentifier.cs
+++ b/src/Microsoft.Graph/Models/Generated/MobileAppIdentifier.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class MobileAppIdentifier
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/NetworkConnection.cs
+++ b/src/Microsoft.Graph/Models/Generated/NetworkConnection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class NetworkConnection
     {
-    
+
         /// <summary>
         /// Gets or sets applicationName.
         /// </summary>
@@ -135,6 +135,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/NotebookLinks.cs
+++ b/src/Microsoft.Graph/Models/Generated/NotebookLinks.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class NotebookLinks
     {
-    
+
         /// <summary>
         /// Gets or sets oneNoteClientUrl.
         /// Opens the notebook in the OneNote native client if it's installed.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/NumberColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/NumberColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class NumberColumn
     {
-    
+
         /// <summary>
         /// Gets or sets decimalPlaces.
         /// How many decimal places to display. See below for information about the possible values.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/OmaSetting.cs
+++ b/src/Microsoft.Graph/Models/Generated/OmaSetting.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class OmaSetting
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// Display Name.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/OmaSettingBase64.cs
+++ b/src/Microsoft.Graph/Models/Generated/OmaSettingBase64.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class OmaSettingBase64 : OmaSetting
     {
-    
+        public OmaSettingBase64()
+        {
+            this.ODataType = "microsoft.graph.omaSettingBase64";
+        }
         /// <summary>
         /// Gets or sets fileName.
         /// File name associated with the Value property (.cer

--- a/src/Microsoft.Graph/Models/Generated/OmaSettingBoolean.cs
+++ b/src/Microsoft.Graph/Models/Generated/OmaSettingBoolean.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class OmaSettingBoolean : OmaSetting
     {
-    
+        public OmaSettingBoolean()
+        {
+            this.ODataType = "microsoft.graph.omaSettingBoolean";
+        }
         /// <summary>
         /// Gets or sets value.
         /// Value.

--- a/src/Microsoft.Graph/Models/Generated/OmaSettingDateTime.cs
+++ b/src/Microsoft.Graph/Models/Generated/OmaSettingDateTime.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class OmaSettingDateTime : OmaSetting
     {
-    
+        public OmaSettingDateTime()
+        {
+            this.ODataType = "microsoft.graph.omaSettingDateTime";
+        }
         /// <summary>
         /// Gets or sets value.
         /// Value.

--- a/src/Microsoft.Graph/Models/Generated/OmaSettingFloatingPoint.cs
+++ b/src/Microsoft.Graph/Models/Generated/OmaSettingFloatingPoint.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class OmaSettingFloatingPoint : OmaSetting
     {
-    
+        public OmaSettingFloatingPoint()
+        {
+            this.ODataType = "microsoft.graph.omaSettingFloatingPoint";
+        }
         /// <summary>
         /// Gets or sets value.
         /// Value.

--- a/src/Microsoft.Graph/Models/Generated/OmaSettingInteger.cs
+++ b/src/Microsoft.Graph/Models/Generated/OmaSettingInteger.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class OmaSettingInteger : OmaSetting
     {
-    
+        public OmaSettingInteger()
+        {
+            this.ODataType = "microsoft.graph.omaSettingInteger";
+        }
         /// <summary>
         /// Gets or sets value.
         /// Value.

--- a/src/Microsoft.Graph/Models/Generated/OmaSettingString.cs
+++ b/src/Microsoft.Graph/Models/Generated/OmaSettingString.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class OmaSettingString : OmaSetting
     {
-    
+        public OmaSettingString()
+        {
+            this.ODataType = "microsoft.graph.omaSettingString";
+        }
         /// <summary>
         /// Gets or sets value.
         /// Value.

--- a/src/Microsoft.Graph/Models/Generated/OmaSettingStringXml.cs
+++ b/src/Microsoft.Graph/Models/Generated/OmaSettingStringXml.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class OmaSettingStringXml : OmaSetting
     {
-    
+        public OmaSettingStringXml()
+        {
+            this.ODataType = "microsoft.graph.omaSettingStringXml";
+        }
         /// <summary>
         /// Gets or sets fileName.
         /// File name associated with the Value property (.xml).

--- a/src/Microsoft.Graph/Models/Generated/OnPremisesExtensionAttributes.cs
+++ b/src/Microsoft.Graph/Models/Generated/OnPremisesExtensionAttributes.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class OnPremisesExtensionAttributes
     {
-    
+
         /// <summary>
         /// Gets or sets extensionAttribute1.
         /// </summary>
@@ -117,6 +117,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/OnPremisesProvisioningError.cs
+++ b/src/Microsoft.Graph/Models/Generated/OnPremisesProvisioningError.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class OnPremisesProvisioningError
     {
-    
+
         /// <summary>
         /// Gets or sets value.
         /// </summary>
@@ -51,6 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/OnenoteOperationError.cs
+++ b/src/Microsoft.Graph/Models/Generated/OnenoteOperationError.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class OnenoteOperationError
     {
-    
+
         /// <summary>
         /// Gets or sets code.
         /// The error code.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/OnenotePagePreview.cs
+++ b/src/Microsoft.Graph/Models/Generated/OnenotePagePreview.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class OnenotePagePreview
     {
-    
+
         /// <summary>
         /// Gets or sets previewText.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/OnenotePagePreviewLinks.cs
+++ b/src/Microsoft.Graph/Models/Generated/OnenotePagePreviewLinks.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class OnenotePagePreviewLinks
     {
-    
+
         /// <summary>
         /// Gets or sets previewImageUrl.
         /// </summary>
@@ -33,6 +33,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/OnenotePatchContentCommand.cs
+++ b/src/Microsoft.Graph/Models/Generated/OnenotePatchContentCommand.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class OnenotePatchContentCommand
     {
-    
+
         /// <summary>
         /// Gets or sets action.
         /// The action to perform on the target element. Possible values are: replace, append, delete, insert, or prepend.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/OutlookGeoCoordinates.cs
+++ b/src/Microsoft.Graph/Models/Generated/OutlookGeoCoordinates.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class OutlookGeoCoordinates
     {
-    
+
         /// <summary>
         /// Gets or sets altitude.
         /// The altitude of the location.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Package.cs
+++ b/src/Microsoft.Graph/Models/Generated/Package.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Package
     {
-    
+
         /// <summary>
         /// Gets or sets type.
         /// </summary>
@@ -33,6 +33,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PageLinks.cs
+++ b/src/Microsoft.Graph/Models/Generated/PageLinks.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PageLinks
     {
-    
+
         /// <summary>
         /// Gets or sets oneNoteClientUrl.
         /// Opens the page in the OneNote native client if it's installed.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PasswordProfile.cs
+++ b/src/Microsoft.Graph/Models/Generated/PasswordProfile.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PasswordProfile
     {
-    
+
         /// <summary>
         /// Gets or sets password.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PatternedRecurrence.cs
+++ b/src/Microsoft.Graph/Models/Generated/PatternedRecurrence.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PatternedRecurrence
     {
-    
+
         /// <summary>
         /// Gets or sets pattern.
         /// The frequency of an event.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PersonOrGroupColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/PersonOrGroupColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PersonOrGroupColumn
     {
-    
+
         /// <summary>
         /// Gets or sets allowMultipleSelection.
         /// Indicates whether multiple values can be selected from the source.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PersonType.cs
+++ b/src/Microsoft.Graph/Models/Generated/PersonType.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PersonType
     {
-    
+
         /// <summary>
         /// Gets or sets class.
         /// The type of data source, such as Person.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Phone.cs
+++ b/src/Microsoft.Graph/Models/Generated/Phone.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Phone
     {
-    
+
         /// <summary>
         /// Gets or sets type.
         /// The type of phone number. Possible values are: home, business, mobile, other, assistant, homeFax, businessFax, otherFax, pager, radio.
@@ -53,6 +53,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Photo.cs
+++ b/src/Microsoft.Graph/Models/Generated/Photo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Photo
     {
-    
+
         /// <summary>
         /// Gets or sets cameraMake.
         /// Camera manufacturer. Read-only.
@@ -83,6 +83,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PhysicalAddress.cs
+++ b/src/Microsoft.Graph/Models/Generated/PhysicalAddress.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PhysicalAddress
     {
-    
+
         /// <summary>
         /// Gets or sets street.
         /// The street.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerAppliedCategories.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerAppliedCategories.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerAppliedCategories
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerAssignment.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerAssignment.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerAssignment
     {
-    
+
         /// <summary>
         /// Gets or sets assignedBy.
         /// The identity of the user that performed the assignment of the task, i.e. the assignor.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerAssignments.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerAssignments.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerAssignments
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerCategoryDescriptions.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerCategoryDescriptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerCategoryDescriptions
     {
-    
+
         /// <summary>
         /// Gets or sets category1.
         /// The label associated with Category 1
@@ -69,6 +69,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerChecklistItem.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerChecklistItem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerChecklistItem
     {
-    
+
         /// <summary>
         /// Gets or sets isChecked.
         /// Value is true if the item is checked and false otherwise.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerChecklistItems.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerChecklistItems.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerChecklistItems
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerExternalReference.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerExternalReference.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerExternalReference
     {
-    
+
         /// <summary>
         /// Gets or sets alias.
         /// A name alias to describe the reference.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerExternalReferences.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerExternalReferences.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerExternalReferences
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerOrderHintsByAssignee.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerOrderHintsByAssignee.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerOrderHintsByAssignee
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PlannerUserIds.cs
+++ b/src/Microsoft.Graph/Models/Generated/PlannerUserIds.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PlannerUserIds
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PrivacyProfile.cs
+++ b/src/Microsoft.Graph/Models/Generated/PrivacyProfile.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PrivacyProfile
     {
-    
+
         /// <summary>
         /// Gets or sets contactEmail.
         /// A valid smtp email address for the privacy statement contact. Not required.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Process.cs
+++ b/src/Microsoft.Graph/Models/Generated/Process.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Process
     {
-    
+
         /// <summary>
         /// Gets or sets accountName.
         /// </summary>
@@ -99,6 +99,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ProvisionedPlan.cs
+++ b/src/Microsoft.Graph/Models/Generated/ProvisionedPlan.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ProvisionedPlan
     {
-    
+
         /// <summary>
         /// Gets or sets capabilityStatus.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ProxiedDomain.cs
+++ b/src/Microsoft.Graph/Models/Generated/ProxiedDomain.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ProxiedDomain
     {
-    
+
         /// <summary>
         /// Gets or sets ipAddressOrFQDN.
         /// The IP address or FQDN
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/PublicationFacet.cs
+++ b/src/Microsoft.Graph/Models/Generated/PublicationFacet.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class PublicationFacet
     {
-    
+
         /// <summary>
         /// Gets or sets level.
         /// The state of publication for this document. Either published or checkout. Read-only.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Quota.cs
+++ b/src/Microsoft.Graph/Models/Generated/Quota.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Quota
     {
-    
+
         /// <summary>
         /// Gets or sets deleted.
         /// Total space consumed by files in the recycle bin, in bytes. Read-only.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RecentNotebook.cs
+++ b/src/Microsoft.Graph/Models/Generated/RecentNotebook.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class RecentNotebook
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// </summary>
@@ -54,6 +54,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RecentNotebookLinks.cs
+++ b/src/Microsoft.Graph/Models/Generated/RecentNotebookLinks.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class RecentNotebookLinks
     {
-    
+
         /// <summary>
         /// Gets or sets oneNoteClientUrl.
         /// Opens the notebook in the OneNote native client if it's installed.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Recipient.cs
+++ b/src/Microsoft.Graph/Models/Generated/Recipient.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Recipient
     {
-    
+
         /// <summary>
         /// Gets or sets emailAddress.
         /// The recipient's email address.
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RecurrencePattern.cs
+++ b/src/Microsoft.Graph/Models/Generated/RecurrencePattern.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class RecurrencePattern
     {
-    
+
         /// <summary>
         /// Gets or sets type.
         /// The recurrence pattern type: daily, weekly, absoluteMonthly, relativeMonthly, absoluteYearly, relativeYearly. Required.
@@ -76,6 +76,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RecurrenceRange.cs
+++ b/src/Microsoft.Graph/Models/Generated/RecurrenceRange.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class RecurrenceRange
     {
-    
+
         /// <summary>
         /// Gets or sets type.
         /// The recurrence range. Possible values are: endDate, noEnd, numbered. Required.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RegistryKeyState.cs
+++ b/src/Microsoft.Graph/Models/Generated/RegistryKeyState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class RegistryKeyState
     {
-    
+
         /// <summary>
         /// Gets or sets hive.
         /// </summary>
@@ -87,6 +87,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Reminder.cs
+++ b/src/Microsoft.Graph/Models/Generated/Reminder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Reminder
     {
-    
+
         /// <summary>
         /// Gets or sets eventId.
         /// The unique ID of the event. Read only.
@@ -83,6 +83,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RemoteItem.cs
+++ b/src/Microsoft.Graph/Models/Generated/RemoteItem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class RemoteItem
     {
-    
+
         /// <summary>
         /// Gets or sets createdBy.
         /// Identity of the user, device, and application which created the item. Read-only.
@@ -145,6 +145,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RemoteLockActionResult.cs
+++ b/src/Microsoft.Graph/Models/Generated/RemoteLockActionResult.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class RemoteLockActionResult : DeviceActionResult
     {
-    
+
         /// <summary>
         /// Gets or sets unlockPin.
         /// Pin to unlock the client

--- a/src/Microsoft.Graph/Models/Generated/Report.cs
+++ b/src/Microsoft.Graph/Models/Generated/Report.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Report
     {
-    
+
         /// <summary>
         /// Gets or sets content.
         /// Not yet documented
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ResetPasscodeActionResult.cs
+++ b/src/Microsoft.Graph/Models/Generated/ResetPasscodeActionResult.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class ResetPasscodeActionResult : DeviceActionResult
     {
-    
+
         /// <summary>
         /// Gets or sets passcode.
         /// Newly generated passcode for the device

--- a/src/Microsoft.Graph/Models/Generated/ResourceAction.cs
+++ b/src/Microsoft.Graph/Models/Generated/ResourceAction.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ResourceAction
     {
-    
+
         /// <summary>
         /// Gets or sets allowedResourceActions.
         /// Allowed Actions
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ResourceReference.cs
+++ b/src/Microsoft.Graph/Models/Generated/ResourceReference.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ResourceReference
     {
-    
+
         /// <summary>
         /// Gets or sets webUrl.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ResourceVisualization.cs
+++ b/src/Microsoft.Graph/Models/Generated/ResourceVisualization.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ResourceVisualization
     {
-    
+
         /// <summary>
         /// Gets or sets title.
         /// </summary>
@@ -75,6 +75,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ResponseStatus.cs
+++ b/src/Microsoft.Graph/Models/Generated/ResponseStatus.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ResponseStatus
     {
-    
+
         /// <summary>
         /// Gets or sets response.
         /// The response type. Possible values are: None, Organizer, TentativelyAccepted, Accepted, Declined, NotResponded.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RgbColor.cs
+++ b/src/Microsoft.Graph/Models/Generated/RgbColor.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class RgbColor
     {
-    
+
         /// <summary>
         /// Gets or sets r.
         /// Red value
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/RolePermission.cs
+++ b/src/Microsoft.Graph/Models/Generated/RolePermission.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class RolePermission
     {
-    
+
         /// <summary>
         /// Gets or sets resourceActions.
         /// Actions
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Root.cs
+++ b/src/Microsoft.Graph/Models/Generated/Root.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Root
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ScoredEmailAddress.cs
+++ b/src/Microsoft.Graph/Models/Generated/ScoredEmailAddress.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ScoredEmailAddress
     {
-    
+
         /// <summary>
         /// Gets or sets address.
         /// The email address.
@@ -53,6 +53,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SearchResult.cs
+++ b/src/Microsoft.Graph/Models/Generated/SearchResult.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SearchResult
     {
-    
+
         /// <summary>
         /// Gets or sets onClickTelemetryUrl.
         /// A callback URL that can be used to record telemetry information. The application should issue a GET on this URL if the user interacts with this item to improve the quality of results.
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SectionLinks.cs
+++ b/src/Microsoft.Graph/Models/Generated/SectionLinks.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SectionLinks
     {
-    
+
         /// <summary>
         /// Gets or sets oneNoteClientUrl.
         /// Opens the section in the OneNote native client if it's installed.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SecurityVendorInformation.cs
+++ b/src/Microsoft.Graph/Models/Generated/SecurityVendorInformation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SecurityVendorInformation
     {
-    
+
         /// <summary>
         /// Gets or sets provider.
         /// </summary>
@@ -51,6 +51,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/ServicePlanInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/ServicePlanInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class ServicePlanInfo
     {
-    
+
         /// <summary>
         /// Gets or sets servicePlanId.
         /// The unique identifier of the service plan.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SettingSource.cs
+++ b/src/Microsoft.Graph/Models/Generated/SettingSource.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SettingSource
     {
-    
+
         /// <summary>
         /// Gets or sets id.
         /// Not yet documented
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SettingTemplateValue.cs
+++ b/src/Microsoft.Graph/Models/Generated/SettingTemplateValue.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SettingTemplateValue
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// Name of the setting.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SettingValue.cs
+++ b/src/Microsoft.Graph/Models/Generated/SettingValue.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SettingValue
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// Name of the setting (as defined by the groupSettingTemplate).
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Shared.cs
+++ b/src/Microsoft.Graph/Models/Generated/Shared.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Shared
     {
-    
+
         /// <summary>
         /// Gets or sets owner.
         /// The identity of the owner of the shared item. Read-only.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SharedPCAccountManagerPolicy.cs
+++ b/src/Microsoft.Graph/Models/Generated/SharedPCAccountManagerPolicy.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SharedPCAccountManagerPolicy
     {
-    
+
         /// <summary>
         /// Gets or sets accountDeletionPolicy.
         /// Configures when accounts are deleted. Possible values are: immediate, diskSpaceThreshold, diskSpaceThresholdOrInactiveThreshold.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SharepointIds.cs
+++ b/src/Microsoft.Graph/Models/Generated/SharepointIds.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SharepointIds
     {
-    
+
         /// <summary>
         /// Gets or sets listId.
         /// The unique identifier (guid) for the item's list in SharePoint.
@@ -69,6 +69,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SharingDetail.cs
+++ b/src/Microsoft.Graph/Models/Generated/SharingDetail.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SharingDetail
     {
-    
+
         /// <summary>
         /// Gets or sets sharedBy.
         /// </summary>
@@ -57,6 +57,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SharingInvitation.cs
+++ b/src/Microsoft.Graph/Models/Generated/SharingInvitation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SharingInvitation
     {
-    
+
         /// <summary>
         /// Gets or sets email.
         /// The email address provided for the recipient of the sharing invitation. Read-only.
@@ -54,6 +54,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SharingLink.cs
+++ b/src/Microsoft.Graph/Models/Generated/SharingLink.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SharingLink
     {
-    
+
         /// <summary>
         /// Gets or sets application.
         /// The app the link is associated with.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SiteCollection.cs
+++ b/src/Microsoft.Graph/Models/Generated/SiteCollection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SiteCollection
     {
-    
+
         /// <summary>
         /// Gets or sets hostname.
         /// The hostname for the site collection. Read-only.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SizeRange.cs
+++ b/src/Microsoft.Graph/Models/Generated/SizeRange.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SizeRange
     {
-    
+
         /// <summary>
         /// Gets or sets minimumSize.
         /// The minimum size (in kilobytes) that an incoming message must have in order for a condition or exception to apply.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SpecialFolder.cs
+++ b/src/Microsoft.Graph/Models/Generated/SpecialFolder.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SpecialFolder
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// The unique identifier for this item in the /drive/special collection
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/StandardTimeZoneOffset.cs
+++ b/src/Microsoft.Graph/Models/Generated/StandardTimeZoneOffset.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class StandardTimeZoneOffset
     {
-    
+
         /// <summary>
         /// Gets or sets time.
         /// Represents the time of day when the transition from daylight saving time to standard time occurs.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/SystemFacet.cs
+++ b/src/Microsoft.Graph/Models/Generated/SystemFacet.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class SystemFacet
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/TextColumn.cs
+++ b/src/Microsoft.Graph/Models/Generated/TextColumn.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class TextColumn
     {
-    
+
         /// <summary>
         /// Gets or sets allowMultipleLines.
         /// Whether to allow multiple lines of text.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Thumbnail.cs
+++ b/src/Microsoft.Graph/Models/Generated/Thumbnail.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Thumbnail
     {
-    
+
         /// <summary>
         /// Gets or sets content.
         /// </summary>
@@ -61,6 +61,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/TimeConstraint.cs
+++ b/src/Microsoft.Graph/Models/Generated/TimeConstraint.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class TimeConstraint
     {
-    
+
         /// <summary>
         /// Gets or sets activityDomain.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/TimeSlot.cs
+++ b/src/Microsoft.Graph/Models/Generated/TimeSlot.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class TimeSlot
     {
-    
+
         /// <summary>
         /// Gets or sets start.
         /// The time the period ends.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/TimeZoneBase.cs
+++ b/src/Microsoft.Graph/Models/Generated/TimeZoneBase.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class TimeZoneBase
     {
-    
+
         /// <summary>
         /// Gets or sets name.
         /// The name of a time zone. It can be a standard time zone name such as "Hawaii-Aleutian Standard Time", or "Customized Time Zone" for a custom time zone.
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/TimeZoneInformation.cs
+++ b/src/Microsoft.Graph/Models/Generated/TimeZoneInformation.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class TimeZoneInformation
     {
-    
+
         /// <summary>
         /// Gets or sets alias.
         /// An identifier for the time zone.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/UpdateWindowsDeviceAccountActionParameter.cs
+++ b/src/Microsoft.Graph/Models/Generated/UpdateWindowsDeviceAccountActionParameter.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class UpdateWindowsDeviceAccountActionParameter
     {
-    
+
         /// <summary>
         /// Gets or sets deviceAccount.
         /// Not yet documented
@@ -69,6 +69,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/UploadSession.cs
+++ b/src/Microsoft.Graph/Models/Generated/UploadSession.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class UploadSession
     {
-    
+
         /// <summary>
         /// Gets or sets expirationDateTime.
         /// The date and time in UTC that the upload session will expire. The complete file must be uploaded before this expiration time is reached.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/UsageDetails.cs
+++ b/src/Microsoft.Graph/Models/Generated/UsageDetails.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class UsageDetails
     {
-    
+
         /// <summary>
         /// Gets or sets lastAccessedDateTime.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/UserSecurityState.cs
+++ b/src/Microsoft.Graph/Models/Generated/UserSecurityState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class UserSecurityState
     {
-    
+
         /// <summary>
         /// Gets or sets aadUserId.
         /// </summary>
@@ -111,6 +111,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/VerifiedDomain.cs
+++ b/src/Microsoft.Graph/Models/Generated/VerifiedDomain.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class VerifiedDomain
     {
-    
+
         /// <summary>
         /// Gets or sets capabilities.
         /// </summary>
@@ -57,6 +57,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Video.cs
+++ b/src/Microsoft.Graph/Models/Generated/Video.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Video
     {
-    
+
         /// <summary>
         /// Gets or sets audioBitsPerSample.
         /// Number of audio bits per sample.
@@ -96,6 +96,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/VisualInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/VisualInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class VisualInfo
     {
-    
+
         /// <summary>
         /// Gets or sets attribution.
         /// Optional. JSON object used to represent an icon which represents the application used to generate the activity
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/VppLicensingType.cs
+++ b/src/Microsoft.Graph/Models/Generated/VppLicensingType.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class VppLicensingType
     {
-    
+
         /// <summary>
         /// Gets or sets supportsUserLicensing.
         /// Whether the program supports the user licensing type.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/VulnerabilityState.cs
+++ b/src/Microsoft.Graph/Models/Generated/VulnerabilityState.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class VulnerabilityState
     {
-    
+
         /// <summary>
         /// Gets or sets cve.
         /// </summary>
@@ -45,6 +45,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Website.cs
+++ b/src/Microsoft.Graph/Models/Generated/Website.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Website
     {
-    
+
         /// <summary>
         /// Gets or sets type.
         /// Possible values are: other, home, work, blog, profile.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/Windows10NetworkProxyServer.cs
+++ b/src/Microsoft.Graph/Models/Generated/Windows10NetworkProxyServer.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class Windows10NetworkProxyServer
     {
-    
+
         /// <summary>
         /// Gets or sets address.
         /// Address to the proxy server. Specify an address in the format [":"]
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsDefenderScanActionResult.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsDefenderScanActionResult.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class WindowsDefenderScanActionResult : DeviceActionResult
     {
-    
+
         /// <summary>
         /// Gets or sets scanType.
         /// Scan type either full scan or quick scan

--- a/src/Microsoft.Graph/Models/Generated/WindowsDeviceADAccount.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsDeviceADAccount.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class WindowsDeviceADAccount : WindowsDeviceAccount
     {
-    
+
         /// <summary>
         /// Gets or sets domainName.
         /// Not yet documented

--- a/src/Microsoft.Graph/Models/Generated/WindowsDeviceAccount.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsDeviceAccount.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WindowsDeviceAccount
     {
-    
+
         /// <summary>
         /// Gets or sets password.
         /// Not yet documented
@@ -34,6 +34,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsDeviceAzureADAccount.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsDeviceAzureADAccount.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class WindowsDeviceAzureADAccount : WindowsDeviceAccount
     {
-    
+
         /// <summary>
         /// Gets or sets userPrincipalName.
         /// Not yet documented

--- a/src/Microsoft.Graph/Models/Generated/WindowsFirewallNetworkProfile.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsFirewallNetworkProfile.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WindowsFirewallNetworkProfile
     {
-    
+
         /// <summary>
         /// Gets or sets firewallEnabled.
         /// Turn on the firewall and advanced security enforcement. Possible values are: notConfigured, blocked, allowed.
@@ -111,6 +111,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionApp.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionApp.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class WindowsInformationProtectionApp
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// App display name.
@@ -62,6 +62,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionDataRecoveryCertificate.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionDataRecoveryCertificate.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WindowsInformationProtectionDataRecoveryCertificate
     {
-    
+
         /// <summary>
         /// Gets or sets subjectName.
         /// Data recovery Certificate subject name
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionDesktopApp.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionDesktopApp.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class WindowsInformationProtectionDesktopApp : WindowsInformationProtectionApp
     {
-    
+        public WindowsInformationProtectionDesktopApp()
+        {
+            this.ODataType = "microsoft.graph.windowsInformationProtectionDesktopApp";
+        }
         /// <summary>
         /// Gets or sets binaryName.
         /// The binary name.

--- a/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionIPRangeCollection.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionIPRangeCollection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WindowsInformationProtectionIPRangeCollection
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// Display name
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionProxiedDomainCollection.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionProxiedDomainCollection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WindowsInformationProtectionProxiedDomainCollection
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// Display name
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionResourceCollection.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionResourceCollection.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WindowsInformationProtectionResourceCollection
     {
-    
+
         /// <summary>
         /// Gets or sets displayName.
         /// Display name
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionStoreApp.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsInformationProtectionStoreApp.cs
@@ -20,6 +20,9 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class WindowsInformationProtectionStoreApp : WindowsInformationProtectionApp
     {
-    
+        public WindowsInformationProtectionStoreApp()
+        {
+            this.ODataType = "microsoft.graph.windowsInformationProtectionStoreApp";
+        }
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsMinimumOperatingSystem.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsMinimumOperatingSystem.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WindowsMinimumOperatingSystem
     {
-    
+
         /// <summary>
         /// Gets or sets v8_0.
         /// Windows version 8.0 or later.
@@ -48,6 +48,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsUpdateActiveHoursInstall.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsUpdateActiveHoursInstall.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class WindowsUpdateActiveHoursInstall : WindowsUpdateInstallScheduleType
     {
-    
+        public WindowsUpdateActiveHoursInstall()
+        {
+            this.ODataType = "microsoft.graph.windowsUpdateActiveHoursInstall";
+        }
         /// <summary>
         /// Gets or sets activeHoursStart.
         /// Active Hours Start

--- a/src/Microsoft.Graph/Models/Generated/WindowsUpdateInstallScheduleType.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsUpdateInstallScheduleType.cs
@@ -21,12 +21,18 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public abstract partial class WindowsUpdateInstallScheduleType
     {
-    
+
         /// <summary>
         /// Gets or sets additional data.
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WindowsUpdateScheduledInstall.cs
+++ b/src/Microsoft.Graph/Models/Generated/WindowsUpdateScheduledInstall.cs
@@ -20,7 +20,10 @@ namespace Microsoft.Graph
     [JsonObject(MemberSerialization = MemberSerialization.OptIn)]
     public partial class WindowsUpdateScheduledInstall : WindowsUpdateInstallScheduleType
     {
-    
+        public WindowsUpdateScheduledInstall()
+        {
+            this.ODataType = "microsoft.graph.windowsUpdateScheduledInstall";
+        }
         /// <summary>
         /// Gets or sets scheduledInstallDay.
         /// Scheduled Install Day in week. Possible values are: userDefined, everyday, sunday, monday, tuesday, wednesday, thursday, friday, saturday.

--- a/src/Microsoft.Graph/Models/Generated/WorkbookFilterCriteria.cs
+++ b/src/Microsoft.Graph/Models/Generated/WorkbookFilterCriteria.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WorkbookFilterCriteria
     {
-    
+
         /// <summary>
         /// Gets or sets color.
         /// </summary>
@@ -75,6 +75,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WorkbookFilterDatetime.cs
+++ b/src/Microsoft.Graph/Models/Generated/WorkbookFilterDatetime.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WorkbookFilterDatetime
     {
-    
+
         /// <summary>
         /// Gets or sets date.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WorkbookIcon.cs
+++ b/src/Microsoft.Graph/Models/Generated/WorkbookIcon.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WorkbookIcon
     {
-    
+
         /// <summary>
         /// Gets or sets index.
         /// </summary>
@@ -39,6 +39,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WorkbookRangeReference.cs
+++ b/src/Microsoft.Graph/Models/Generated/WorkbookRangeReference.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WorkbookRangeReference
     {
-    
+
         /// <summary>
         /// Gets or sets address.
         /// </summary>
@@ -33,6 +33,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WorkbookSessionInfo.cs
+++ b/src/Microsoft.Graph/Models/Generated/WorkbookSessionInfo.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WorkbookSessionInfo
     {
-    
+
         /// <summary>
         /// Gets or sets id.
         /// Id of the workbook session.
@@ -41,6 +41,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WorkbookSortField.cs
+++ b/src/Microsoft.Graph/Models/Generated/WorkbookSortField.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WorkbookSortField
     {
-    
+
         /// <summary>
         /// Gets or sets ascending.
         /// </summary>
@@ -63,6 +63,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WorkbookWorksheetProtectionOptions.cs
+++ b/src/Microsoft.Graph/Models/Generated/WorkbookWorksheetProtectionOptions.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WorkbookWorksheetProtectionOptions
     {
-    
+
         /// <summary>
         /// Gets or sets allowAutoFilter.
         /// </summary>
@@ -93,6 +93,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }

--- a/src/Microsoft.Graph/Models/Generated/WorkingHours.cs
+++ b/src/Microsoft.Graph/Models/Generated/WorkingHours.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph
     [JsonConverter(typeof(DerivedTypeConverter))]
     public partial class WorkingHours
     {
-    
+
         /// <summary>
         /// Gets or sets daysOfWeek.
         /// The days of the week on which the user works.
@@ -55,6 +55,12 @@ namespace Microsoft.Graph
         /// </summary>
         [JsonExtensionData(ReadData = true)]
         public IDictionary<string, object> AdditionalData { get; set; }
+
+        /// <summary>
+        /// Gets or sets @odata.type.
+        /// </summary>
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "@odata.type", Required = Newtonsoft.Json.Required.Default)]
+        public string ODataType { get; set; }
     
     }
 }


### PR DESCRIPTION
Added constructors to initialize OdataType for classes that have an abstract base that is referenced as the type of a property. This fixes #294

https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/pull/154

The result is that all complexTypes have an ODataType property and any complexTypes with an abstract base that is referenced as a property's type will have its odata.type set on it, such as [OmaSettingsString.cs](https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/addOdataTypeForComplexType/src/Microsoft.Graph/Models/Generated/OmaSettingString.cs). 
