### PR TITLE
Add GraphClientFactory class for middle ware 

### DIFF
--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -21,6 +21,10 @@ namespace Microsoft.Graph
             internal static string TooManyRedirects = "tooManyRedirects";
 
             internal static string TooManyRetries = "tooManyRetries";
+
+            internal static string DelegatingHandlerArray = "DelegatingHandlerArray";
+
+            internal static string DelegatingHandlerArrayInnerHandler = "DelegatingHandlerArrayInnerHandler";
         }
 
         internal static class Messages
@@ -50,6 +54,10 @@ namespace Microsoft.Graph
             internal static string UnexpectedExceptionOnSend = "An error occurred sending the request.";
 
             internal static string UnexpectedExceptionResponse = "Unexpected exception returned from the service.";
+
+            internal static string DelegatingHandlerArrayContainsNullItem = "DelegatingHandler array contains null item.";
+
+            internal static string DelegatingHandlerArrayHasNullInnerHandler = "DelegatingHandler array has null InnerHandler.";
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -22,9 +22,7 @@ namespace Microsoft.Graph
 
             internal static string TooManyRetries = "tooManyRetries";
 
-            internal static string DelegatingHandlerArray = "DelegatingHandlerArray";
-
-            internal static string DelegatingHandlerArrayInnerHandler = "DelegatingHandlerArrayInnerHandler";
+           
         }
 
         internal static class Messages
@@ -55,9 +53,6 @@ namespace Microsoft.Graph
 
             internal static string UnexpectedExceptionResponse = "Unexpected exception returned from the service.";
 
-            internal static string DelegatingHandlerArrayContainsNullItem = "DelegatingHandler array contains null item.";
-
-            internal static string DelegatingHandlerArrayHasNullInnerHandler = "DelegatingHandler array has null InnerHandler.";
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -1,0 +1,202 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Net.Http.Headers;
+
+
+namespace Microsoft.Graph
+{
+    public static class GraphClientFactory
+    {
+        private enum GraphServiceCloudList
+        {
+            Global = 1,
+            US = 2,
+            China = 3
+        }
+        /// The key for the SDK version header.
+        private static readonly string SdkVersionHeaderName = CoreConstants.Headers.SdkVersionHeaderName;
+
+        /// The version for current assembly.
+        private static Version assemblyVersion = typeof(GraphClientFactory).GetTypeInfo().Assembly.GetName().Version;
+
+        /// The value for the SDK version header.
+        private static string SdkVersionHeaderValue = string.Format(
+                    CoreConstants.Headers.SdkVersionHeaderValueFormatString,
+                    "Graph",
+                    assemblyVersion.Major,
+                    assemblyVersion.Minor,
+                    assemblyVersion.Build);
+
+        /// The default value for the overall request timeout.
+        private static readonly TimeSpan defaultTimeout = TimeSpan.FromSeconds(100);
+
+     
+        /// The default value for the baseAddress of HTTP client
+        private static readonly Uri _baseAddress = new Uri("https://graph.microsoft.com/v1.0");
+
+        /// <summary>
+        /// Creates a new <see cref="HttpClient"/> instance configured with the handlers provided.
+        /// </summary>
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as an 
+        /// <see cref="HttpRequestMessage"/> travels from the <see cref="HttpClient"/> to the network and an 
+        /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
+        /// an outbound request message but last for an inbound response message.</param>
+        /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
+        public static HttpClient CreateClient(DelegatingHandler[] handlers)
+        {
+            return CreateClient(handlers, defaultTimeout);
+        }
+
+        public static HttpClient CreateClient(DelegatingHandler[] handlers)
+        {
+            return CreateClient(handlers, defaultTimeout);
+        }
+
+
+        /// <summary>
+        /// Creates a new <see cref="HttpClient"/> instance configured with the handlers, timeout, baseAddress,
+        /// cacheControlHeaderValue and proxy provided.
+        /// </summary>
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as an 
+        /// <see cref="HttpRequestMessage"/> travels from the <see cref="HttpClient"/> to the network and an 
+        /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
+        /// an outbound request message but last for an inbound response message.</param>
+        /// <param name="timeout">A <see cref="TimeSpan"/> object to be passed to the client's Timeout property</param>
+        /// <param name="baseAddress">A <see cref="string"/> value to be setted as the client's BaseAddress property</param>
+        /// <param name="cacheControlHeaderValue">A <see cref="CacheControlHeaderValue"/> object to be passed to Client's CacheControlHeaderValue 
+        /// in DefaultRequestHeaders property.</param>
+        /// <param name="proxy">A <see cref="WebProxy"/> object to be passed to client to configure InnderHandler's proxy property.</param>
+        /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
+        public static HttpClient CreateClient(DelegatingHandler[] handlers, TimeSpan timeout, Uri baseAddress = null, CacheControlHeaderValue cacheControlHeaderValue = null, WebProxy proxy = null)
+        {
+            HttpClientHandler handler = new HttpClientHandler();
+            if (proxy != null)
+            {
+                handler.Proxy = proxy;
+            }
+
+            HttpClient client = Create(handler, handlers);
+
+            if (timeout == null)
+            {
+                timeout = defaultTimeout;
+            }
+
+            return Configure(client, timeout, baseAddress, cacheControlHeaderValue);
+
+        }
+
+
+
+        /// <summary>
+        /// Creates a new <see cref="HttpClient"/> instance configured with the handlers provided and with the
+        /// provided <paramref name="innerHandler"/> as the innermost handler.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler represents the destination of the HTTP message channel.</param>
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as an 
+        /// <see cref="HttpRequestMessage"/> travels from the <see cref="HttpClient"/> to the network and an 
+        /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
+        /// an outbound request message but last for an inbound response message.</param>
+        /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
+        public static HttpClient Create(HttpMessageHandler innerHandler, params DelegatingHandler[] handlers)
+        {
+            HttpMessageHandler pipeline = CreatePipeline(innerHandler, handlers);
+            HttpClient client = new HttpClient(pipeline);
+            client.DefaultRequestHeaders.Add(SdkVersionHeaderName, SdkVersionHeaderValue);
+            return client;
+        }
+
+        /// <summary>
+        /// Creates an instance of an <see cref="HttpMessageHandler"/> using the <see cref="DelegatingHandler"/> instances
+        /// provided by <paramref name="handlers"/>. The resulting pipeline can be used to manually create <see cref="HttpClient"/>
+        /// or <see cref="HttpMessageInvoker"/> instances with customized message handlers.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler represents the destination of the HTTP message channel.</param>
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as part 
+        /// of sending an <see cref="HttpRequestMessage"/> and receiving an <see cref="HttpResponseMessage"/>.
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
+        /// an outbound request message but last for an inbound response message.</param>
+        /// <returns>The HTTP message channel.</returns>
+        public static HttpMessageHandler CreatePipeline(HttpMessageHandler innerHandler, IEnumerable<DelegatingHandler> handlers)
+        {
+            if (innerHandler == null)
+            {
+                innerHandler = new HttpClientHandler();
+            }
+
+            if (handlers == null)
+            {
+                return innerHandler;
+            }
+
+            HttpMessageHandler pipeline = innerHandler;
+            IEnumerable<DelegatingHandler> reversedHandlers = handlers.Reverse();
+            foreach (DelegatingHandler handler in reversedHandlers)
+            {
+                if (handler == null)
+                {
+                    throw new ServiceException(
+                    new Error
+                    {
+                        Code = ErrorConstants.Codes.DelegatingHandlerArray,
+                        Message = ErrorConstants.Messages.DelegatingHandlerArrayContainsNullItem,
+                    });
+                }
+
+                if (handler.InnerHandler != null)
+                {
+                    throw new ServiceException(
+                   new Error
+                   {
+                       Code = ErrorConstants.Codes.DelegatingHandlerArrayInnerHandler,
+                       Message = ErrorConstants.Messages.DelegatingHandlerArrayHasNullInnerHandler,
+                   });
+                }
+
+                handler.InnerHandler = pipeline;
+                pipeline = handler;
+            }
+
+            return pipeline;
+        }
+
+
+        /// <summary>
+        /// Configure an instance of an <see cref="HttpClient"/>
+        /// </summary>
+        /// <param name="client"></param>
+        /// <param name="timeout"></param>
+        /// <param name="baseAddress"></param>
+        /// <param name="cacheControlHeaderValue"></param>
+        /// <returns></returns>
+        private static HttpClient Configure(HttpClient client, TimeSpan timeout, Uri baseAddress, CacheControlHeaderValue cacheControlHeaderValue)
+        {
+            try
+            {
+                client.Timeout = timeout;
+            }
+            catch (InvalidOperationException exception)
+            {
+                throw new ServiceException(
+                    new Error
+                    {
+                        Code = ErrorConstants.Codes.NotAllowed,
+                        Message = ErrorConstants.Messages.OverallTimeoutCannotBeSet,
+                    },
+                    exception);
+            }
+
+            client.BaseAddress = baseAddress == null ? _baseAddress : baseAddress;
+            client.DefaultRequestHeaders.CacheControl = cacheControlHeaderValue ?? new CacheControlHeaderValue { NoCache = true, NoStore = true };
+            return client;
+        }
+
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -11,13 +11,31 @@ namespace Microsoft.Graph
     using System.Reflection;
     using System.Net.Http.Headers;
 
+    /// <summary>
+    /// Enum value to represent Microsoft graph service national cloud root endpoints
+    /// </summary>
     public enum GraphServieCloudList {
+        /// <summary>
+        /// Global endpoint
+        /// </summary>
         Global = 0,
+        /// <summary>
+        /// US_GOV endpoint
+        /// </summary>
         US_GOV = 1,
+        /// <summary>
+        /// China endpoint
+        /// </summary>
         China = 2,
+        /// <summary>
+        /// Germany endpoint
+        /// </summary>
         Germany = 3
     }
 
+    /// <summary>
+    /// GraphClientFactory class to create the HTTP client
+    /// </summary>
     public static class GraphClientFactory
     {
         
@@ -74,12 +92,21 @@ namespace Microsoft.Graph
         /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
         /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
         /// an outbound request message but last for an inbound response message.</param>
-        /// <returns></returns>
+        /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
         public static HttpClient CreateClient(HttpMessageHandler innerHandler, params DelegatingHandler[] handlers)
         {
             return Create(innerHandler, handlers);
         }
-
+        /// <summary>
+        /// Creates a new <see cref="HttpClient"/> instance configured with the handlers provided.
+        /// </summary>
+        /// <param name="sovereignCloud">The <see cref="GraphServieCloudList"/> enum value to pass the national cloud root endpoint to client.</param>
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as an 
+        /// <see cref="HttpRequestMessage"/> travels from the <see cref="HttpClient"/> to the network and an 
+        /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
+        /// an outbound request message but last for an inbound response message.</param>
+        /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
         public static HttpClient CreateClient(GraphServieCloudList sovereignCloud, params DelegatingHandler[] handlers)
         {
             string cloud = cloudList[(int)sovereignCloud];
@@ -92,16 +119,16 @@ namespace Microsoft.Graph
         /// Creates a new <see cref="HttpClient"/> instance configured with the handlers, timeout, baseAddress,
         /// cacheControlHeaderValue and proxy provided.
         /// </summary>
-        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as an 
-        /// <see cref="HttpRequestMessage"/> travels from the <see cref="HttpClient"/> to the network and an 
-        /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
-        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
-        /// an outbound request message but last for an inbound response message.</param>
         /// <param name="timeout">A <see cref="TimeSpan"/> object to be passed to the client's Timeout property</param>
         /// <param name="baseAddress">A <see cref="string"/> value to be setted as the client's BaseAddress property</param>
         /// <param name="cacheControlHeaderValue">A <see cref="CacheControlHeaderValue"/> object to be passed to Client's CacheControlHeaderValue 
         /// in DefaultRequestHeaders property.</param>
         /// <param name="proxy">A <see cref="IWebProxy"/> object to be passed to client to configure InnderHandler's proxy property.</param>
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as an 
+        /// <see cref="HttpRequestMessage"/> travels from the <see cref="HttpClient"/> to the network and an 
+        /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
+        /// an outbound request message but last for an inbound response message.</param>
         /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
         public static HttpClient CreateClient(TimeSpan timeout, Uri baseAddress = null, CacheControlHeaderValue cacheControlHeaderValue = null, IWebProxy proxy = null, params DelegatingHandler[] handlers)
         {
@@ -201,10 +228,10 @@ namespace Microsoft.Graph
         /// <summary>
         /// Configure an instance of an <see cref="HttpClient"/>
         /// </summary>
-        /// <param name="client"></param>
-        /// <param name="timeout"></param>
-        /// <param name="baseAddress"></param>
-        /// <param name="cacheControlHeaderValue"></param>
+        /// <param name="client">The <see cref="HttpClient"/> client instance need to be configured.</param>
+        /// <param name="timeout">A <see cref="TimeSpan"/> value for the HTTP client timeout property.</param>
+        /// <param name="baseAddress">A <see cref="Uri"/> value to set the HTTP client BaseAddress property.</param>
+        /// <param name="cacheControlHeaderValue">A <see cref="CacheControlHeaderValue"/> value to set HTTP client DefaultRequestHeaders property.</param>
         /// <returns></returns>
         private static HttpClient Configure(HttpClient client, TimeSpan timeout, Uri baseAddress, CacheControlHeaderValue cacheControlHeaderValue)
         {

--- a/src/Microsoft.Graph.Core/Requests/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/RedirectHandler.cs
@@ -5,14 +5,10 @@
 namespace Microsoft.Graph
 {
     using System;
-    using System.Collections.Generic;
     using System.Net.Http;
-    using System.Text;
-    using System.Net.Http.Headers;
     using System.Threading;
     using System.Threading.Tasks;
     using System.Net;
-    using System.IO;
 
     /// <summary>
     /// An <see cref="DelegatingHandler"/> implementation using standard .NET libraries.
@@ -21,6 +17,14 @@ namespace Microsoft.Graph
     {
 
         private const int maxRedirects = 5;
+
+
+        /// <summary>
+        /// Constructs a new <see cref="RedirectHandler"/> 
+        /// </summary>
+        public RedirectHandler()
+        {
+        }
 
         /// <summary>
         /// Constructs a new <see cref="RedirectHandler"/> 

--- a/src/Microsoft.Graph.Core/Requests/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/RetryHandler.cs
@@ -1,19 +1,16 @@
 ﻿// ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
-
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using System.Threading;
-using System.Net.Http;
-using System.Net;
-using System.Net.Http.Headers;
-using System.Globalization;
-
 namespace Microsoft.Graph
-{ 
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using System.Threading;
+    using System.Net.Http;
+    using System.Net;
+    using System.Net.Http.Headers;
     /// <summary>
     /// An <see cref="DelegatingHandler"/> implementation using standard .NET libraries.
     /// </summary>
@@ -29,6 +26,13 @@ namespace Microsoft.Graph
         /// MaxRetry property
         /// </summary>
         public int MaxRetry { set; get; } = 10;
+
+        /// <summary>
+        /// Construct a new <see cref="RetryHandler"/>
+        /// </summary>
+        public RetryHandler()
+        {
+        }
 
         /// <summary>
         /// Construct a new <see cref="RetryHandler"/>

--- a/tests/Microsoft.Graph.Core.Test/Microsoft.Graph.Core.Test.csproj
+++ b/tests/Microsoft.Graph.Core.Test/Microsoft.Graph.Core.Test.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Mocks\MockRedirectHandler.cs" />
     <Compile Include="Requests\AsyncMonitorTests.cs" />
     <Compile Include="Requests\BaseRequestBuilderTests.cs" />
+    <Compile Include="Requests\GraphClientFactoryTests.cs" />
     <Compile Include="Requests\RedirectHandlerTests.cs" />
     <Compile Include="Requests\RetryHandlerTests.cs" />
     <Compile Include="Serialization\DurationConverterTests.cs" />

--- a/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -1,0 +1,198 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Core.Test.Requests
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Mocks;
+    using System;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Reflection;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    [TestClass]
+    public class GraphClientFactoryTests
+    {
+        private DelegatingHandler[] handlers = new DelegatingHandler[2];
+        private MockRedirectHandler testHttpMessageHandler;
+
+
+        [TestInitialize]
+        public void Setup()
+        {
+            this.testHttpMessageHandler = new MockRedirectHandler();
+            handlers[0] = new RetryHandler();
+            handlers[1] = new RedirectHandler();
+
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            this.testHttpMessageHandler.Dispose();
+        }
+
+        [TestMethod]
+        public void CreatePipelineWithoutHttpMessageHandlerInput()
+        {
+            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(null, handlers))
+            using (RedirectHandler inner = (RedirectHandler)handler.InnerHandler)
+            using (HttpMessageHandler innerMost = inner.InnerHandler)
+            {
+                Assert.IsNotNull(handler, "Create a middleware pipeline failed.");
+                Assert.IsNotNull(inner, "Create a middleware pipeline failed.");
+                Assert.IsNotNull(innerMost, "Create inner most HttpMessageHandler failed.");
+                Assert.IsInstanceOfType(handler, typeof(RetryHandler), "Pass pipeline failed in first level.");
+                Assert.IsInstanceOfType(inner, typeof(RedirectHandler), "Pass pipeline failed in seconde level.");
+                Assert.IsInstanceOfType(innerMost, typeof(HttpMessageHandler), "Inner most HttpMessageHandler class error.");
+            }
+
+        }
+
+        [TestMethod]
+        public void CreatePipelineWithHttpMessageHandlerInput()
+        {
+            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(this.testHttpMessageHandler, handlers))
+            using (RedirectHandler inner = (RedirectHandler)handler.InnerHandler)
+            using (MockRedirectHandler innerMost = (MockRedirectHandler)inner.InnerHandler)
+            {
+                Assert.IsNotNull(handler, "Create a middleware pipeline failed.");
+                Assert.IsNotNull(inner, "Create a middleware pipeline failed.");
+                Assert.IsNotNull(innerMost, "Create inner most HttpMessageHandler failed.");
+                Assert.IsInstanceOfType(handler, typeof(RetryHandler), "Pass pipeline failed in first level.");
+                Assert.IsInstanceOfType(inner, typeof(RedirectHandler), "Pass pipeline failed in seconde level.");
+                Assert.IsInstanceOfType(innerMost, typeof(MockRedirectHandler), "Inner most HttpMessageHandler class error.");
+            }
+
+        }
+
+
+        [TestMethod]
+        public void CreatePipelineWithoutPipeline()
+        {
+            using (MockRedirectHandler handler = (MockRedirectHandler)GraphClientFactory.CreatePipeline(this.testHttpMessageHandler, null))
+            {
+                Assert.IsNotNull(handler, "Create a middleware pipeline failed.");
+                Assert.IsInstanceOfType(handler, typeof(MockRedirectHandler), "Inner most HttpMessageHandler class error.");
+            }
+        }
+
+        [TestMethod]
+        public void CreateClient_CustomHttpHandlingBehaviors()
+        {
+            var timeout = TimeSpan.FromSeconds(200);
+            var baseAddress = new Uri("https://localhost");
+            var cacheHeader = new CacheControlHeaderValue();
+            var webProxy = new WebProxy("http://127.0.0.1:8888");
+            using (HttpClient client = GraphClientFactory.CreateClient(timeout, baseAddress, cacheHeader, webProxy, handlers))
+            {
+                Assert.IsNotNull(client, "Create Http client failed.");
+                Assert.AreEqual(client.Timeout, timeout, "Unexpected default timeout set.");
+                Assert.IsFalse(client.DefaultRequestHeaders.CacheControl.NoCache, "NoCache true.");
+                Assert.IsFalse(client.DefaultRequestHeaders.CacheControl.NoStore, "NoStore true.");
+                Assert.AreEqual(client.BaseAddress, baseAddress, "Unexpected default baseAddress set.");
+                
+
+            }
+        }
+
+        [TestMethod]
+        public void CreateClient_SelectedCloud()
+        {
+
+            using (HttpClient httpClient = GraphClientFactory.CreateClient(GraphServieCloudList.Germany, handlers))
+            {
+                Assert.IsNotNull(httpClient, "Create Http client failed.");
+                Uri clouldEndpoint = new Uri("https://graph.microsoft.de/v1.0");
+                Assert.AreEqual(httpClient.BaseAddress, clouldEndpoint, "Unexpected endpoint set.");
+                Assert.AreEqual(httpClient.Timeout, TimeSpan.FromSeconds(100), "Default timeout not set.");
+            }
+        }
+
+        [TestMethod]
+        public void CreateClient_WithInnerHandler()
+        {
+
+            using (HttpClient httpClient = GraphClientFactory.CreateClient(this.testHttpMessageHandler, null))
+            {
+                Assert.IsNotNull(httpClient, "Create Http client failed.");
+                Assert.IsTrue(httpClient.DefaultRequestHeaders.Contains(CoreConstants.Headers.SdkVersionHeaderName), "SDK version not set.");
+                Version assemblyVersion = typeof(GraphClientFactory).GetTypeInfo().Assembly.GetName().Version;
+                string value = string.Format(
+                    CoreConstants.Headers.SdkVersionHeaderValueFormatString,
+                    "Graph",
+                    assemblyVersion.Major,
+                    assemblyVersion.Minor,
+                    assemblyVersion.Build);
+                IEnumerable<string> values;
+                Assert.IsTrue(httpClient.DefaultRequestHeaders.TryGetValues(CoreConstants.Headers.SdkVersionHeaderName, out values), "SDK version value not set");
+                Assert.AreEqual(values.Count(), 1);
+                Assert.AreEqual(values.First(), value);
+            }
+        }
+
+
+        [TestMethod]
+        public void CreateClient_WithHandlers()
+        {
+            using (HttpClient client = GraphClientFactory.CreateClient(handlers))
+            {
+                Assert.IsNotNull(client, "Create Http client failed.");
+
+            }
+
+        }
+
+        [TestMethod]
+        public async Task SendRequest_Redirect()
+        {
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
+            var redirectResponse = new HttpResponseMessage(HttpStatusCode.MovedPermanently);
+
+            redirectResponse.Headers.Location = new Uri("http://example.org/bar");
+            var oKResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            this.testHttpMessageHandler.SetHttpResponse(redirectResponse, oKResponse);
+
+            using (HttpClient client = GraphClientFactory.CreateClient(this.testHttpMessageHandler, handlers))
+            {
+                var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
+                Assert.AreEqual(response, oKResponse, "Middleware pipeline not work.");
+                Assert.AreEqual(response.RequestMessage.Method, httpRequestMessage.Method);
+                Assert.AreNotSame(response.RequestMessage, httpRequestMessage);
+            }
+
+        }
+
+        [TestMethod]
+        public async Task SendRequest_Retry()
+        {
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
+            httpRequestMessage.Content = new StringContent("Hello World");
+
+            var retryResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            retryResponse.Headers.TryAddWithoutValidation("Retry-After", 30.ToString());
+            var response_2 = new HttpResponseMessage(HttpStatusCode.OK);
+
+            this.testHttpMessageHandler.SetHttpResponse(retryResponse, response_2);
+
+            using (HttpClient client = GraphClientFactory.CreateClient(this.testHttpMessageHandler, handlers))
+            {
+                var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
+                Assert.AreSame(response, response_2);
+                IEnumerable<string> values;
+                Assert.IsTrue(httpRequestMessage.Headers.TryGetValues("Retry-Attempt", out values), "Don't set Retry-Attemp Header");
+                Assert.AreEqual(values.Count(), 1);
+                Assert.AreEqual(values.First(), 1.ToString());
+            }
+
+        }
+
+
+    }
+}

--- a/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             }
             catch (ArgumentNullException exception)
             {
-                Assert.IsInstanceOfType(exception, typeof(ArgumentNullException), "Eeception is not the right type");
+                Assert.IsInstanceOfType(exception, typeof(ArgumentNullException), "Exception is not the right type");
                 Assert.AreEqual(exception.ParamName, "handlers", "ParamName not right.");
             }
 
@@ -228,7 +228,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             }
             catch (ArgumentException exception)
             {
-                Assert.IsInstanceOfType(exception, typeof(ArgumentException), "Eeception is not the right type");
+                Assert.IsInstanceOfType(exception, typeof(ArgumentException), "Exception is not the right type");
                 Assert.AreEqual(exception.Message, String.Format("DelegatingHandler array has unexpected InnerHandler. {0} has unexpected InnerHandler.", handlers[1]));
 
             }

--- a/tests/Microsoft.Graph.Core.Test/Requests/RedirectHandlerTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/RedirectHandlerTests.cs
@@ -36,6 +36,16 @@ namespace Microsoft.Graph.Core.Test.Requests
         }
 
         [TestMethod]
+        public void RedirectHandler_Constructor()
+        {
+            using (RedirectHandler redirect = new RedirectHandler())
+            {
+                Assert.IsNull(redirect.InnerHandler, "HttpMessageHandler initialized.");
+                Assert.IsInstanceOfType(redirect, typeof(RedirectHandler), "Unexpected redirect handler set.");
+            }
+        }
+
+        [TestMethod]
         public void RedirectHandler_HttpMessageHandlerConstructor()
         {
             Assert.IsNotNull(redirectHandler.InnerHandler, "HttpMessageHandler not initialized.");

--- a/tests/Microsoft.Graph.Core.Test/Requests/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/RetryHandlerTests.cs
@@ -40,6 +40,17 @@ namespace Microsoft.Graph.Core.Test.Requests
         }
 
         [TestMethod]
+        public void RedtryHandler_Constructor()
+        {
+            using (RetryHandler retry = new RetryHandler())
+            {
+                Assert.IsNull(retry.InnerHandler, "HttpMessageHandler initialized.");
+                Assert.IsInstanceOfType(retry, typeof(RetryHandler), "Unexpected redtry handler set.");
+            }
+        }
+
+
+        [TestMethod]
         public void retryHandler_HttpMessageHandlerConstructor()
         {
             Assert.IsNotNull(retryHandler.InnerHandler, "HttpMessageHandler not initialized.");

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
+    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Microsoft.Graph.DotnetCore.Core.Test.csproj
@@ -18,8 +18,8 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0-preview-20180924-03" />
     <PackageReference Include="Moq" Version="4.8.1" />
-    <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="xunit" Version="2.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockRedirctHandler.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockRedirctHandler.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------------------------
+﻿   // ------------------------------------------------------------------------------
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -1,0 +1,191 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
+{
+    using Mocks;
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Net;
+    using Xunit;
+
+    public class GraphClientFactoryTests : IDisposable
+    {
+        private DelegatingHandler[] handlers = new DelegatingHandler[2];
+        private MockRedirectHandler testHttpMessageHandler;
+
+
+        public GraphClientFactoryTests()
+        {
+            this.testHttpMessageHandler = new MockRedirectHandler();
+            handlers[0] = new RetryHandler();
+            handlers[1] = new RedirectHandler();
+        }
+
+        public void Dispose()
+        {
+            this.testHttpMessageHandler.Dispose();
+        }
+
+        [Fact]
+        public void CreatePipelineWithoutHttpMessageHandlerInput()
+        {
+            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(null, handlers))
+            using (RedirectHandler inner = (RedirectHandler)handler.InnerHandler)
+            using (HttpClientHandler innerMost = (HttpClientHandler)inner.InnerHandler)
+            {
+                Assert.NotNull(handler);
+                Assert.NotNull(inner);
+                Assert.NotNull(innerMost);
+                Assert.IsType(typeof(RetryHandler), handler);
+                Assert.IsType(typeof(RedirectHandler), inner);
+                Assert.IsType(typeof(HttpClientHandler), innerMost);
+            }
+
+        }
+
+        [Fact]
+        public void CreatePipelineWithHttpMessageHandlerInput()
+        {
+            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(this.testHttpMessageHandler, handlers))
+            using (RedirectHandler inner = (RedirectHandler)handler.InnerHandler)
+            using (MockRedirectHandler innerMost = (MockRedirectHandler)inner.InnerHandler)
+            {
+                Assert.NotNull(handler);
+                Assert.NotNull(inner);
+                Assert.NotNull(innerMost);
+                Assert.IsType(typeof(RetryHandler), handler);
+                Assert.IsType(typeof(RedirectHandler), inner);
+                Assert.IsType(typeof(MockRedirectHandler), innerMost);
+            }
+
+        }
+
+
+        [Fact]
+        public void CreatePipelineWithoutPipeline()
+        {
+            using (MockRedirectHandler handler = (MockRedirectHandler)GraphClientFactory.CreatePipeline(this.testHttpMessageHandler, null))
+            {
+                Assert.NotNull(handler);
+                Assert.IsType(typeof(MockRedirectHandler), handler);
+            }
+        }
+
+        [Fact]
+        public void CreateClient_CustomHttpHandlingBehaviors()
+        {
+            var timeout = TimeSpan.FromSeconds(200);
+            var baseAddress = new Uri("https://localhost");
+            var cacheHeader = new CacheControlHeaderValue();
+            
+            using (HttpClient client = GraphClientFactory.CreateClient(timeout, baseAddress, cacheHeader,null, handlers))
+            {
+                Assert.NotNull(client);
+                Assert.Equal(client.Timeout, timeout);
+                Assert.False(client.DefaultRequestHeaders.CacheControl.NoCache, "NoCache true.");
+                Assert.False(client.DefaultRequestHeaders.CacheControl.NoStore, "NoStore true.");
+                Assert.Equal(client.BaseAddress, baseAddress);
+
+            }
+        }
+
+        [Fact]
+        public void CreateClient_SelectedCloud()
+        {
+
+            using (HttpClient httpClient = GraphClientFactory.CreateClient(GraphServieCloudList.Germany, handlers))
+            {
+                Assert.NotNull(httpClient);
+                Uri clouldEndpoint = new Uri("https://graph.microsoft.de/v1.0");
+                Assert.Equal(httpClient.BaseAddress, clouldEndpoint);
+                Assert.Equal(httpClient.Timeout, TimeSpan.FromSeconds(100));
+            }
+        }
+
+        [Fact]
+        public void CreateClient_WithInnerHandler()
+        {
+
+            using (HttpClient httpClient = GraphClientFactory.CreateClient(this.testHttpMessageHandler, null))
+            {
+                Assert.NotNull(httpClient);
+                Assert.True(httpClient.DefaultRequestHeaders.Contains(CoreConstants.Headers.SdkVersionHeaderName), "SDK version not set.");
+                Version assemblyVersion = typeof(GraphClientFactory).GetTypeInfo().Assembly.GetName().Version;
+                string value = string.Format(
+                    CoreConstants.Headers.SdkVersionHeaderValueFormatString,
+                    "Graph",
+                    assemblyVersion.Major,
+                    assemblyVersion.Minor,
+                    assemblyVersion.Build);
+                IEnumerable<string> values;
+                Assert.True(httpClient.DefaultRequestHeaders.TryGetValues(CoreConstants.Headers.SdkVersionHeaderName, out values), "SDK version value not set");
+                Assert.Equal(values.Count(), 1);
+                Assert.Equal(values.First(), value);
+            }
+        }
+
+
+        [Fact]
+        public void CreateClient_WithHandlers()
+        {
+            using (HttpClient client = GraphClientFactory.CreateClient(handlers))
+            {
+                Assert.NotNull(client);
+
+            }
+
+        }
+
+        [Fact]
+        public async Task SendRequest_Redirect()
+        {
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
+            var redirectResponse = new HttpResponseMessage(HttpStatusCode.MovedPermanently);
+
+            redirectResponse.Headers.Location = new Uri("http://example.org/bar");
+            var oKResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            this.testHttpMessageHandler.SetHttpResponse(redirectResponse, oKResponse);
+
+            using (HttpClient client = GraphClientFactory.CreateClient(this.testHttpMessageHandler, handlers))
+            {
+                var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
+                Assert.Equal(response, oKResponse);
+                Assert.Equal(response.RequestMessage.Method, httpRequestMessage.Method);
+                Assert.NotSame(response.RequestMessage, httpRequestMessage);
+            }
+
+        }
+
+        [Fact]
+        public async Task SendRequest_Retry()
+        {
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Post, "http://example.org/foo");
+            httpRequestMessage.Content = new StringContent("Hello World");
+
+            var retryResponse = new HttpResponseMessage(HttpStatusCode.ServiceUnavailable);
+            retryResponse.Headers.TryAddWithoutValidation("Retry-After", 30.ToString());
+            var response_2 = new HttpResponseMessage(HttpStatusCode.OK);
+
+            this.testHttpMessageHandler.SetHttpResponse(retryResponse, response_2);
+
+            using (HttpClient client = GraphClientFactory.CreateClient(this.testHttpMessageHandler, handlers))
+            {
+                var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
+                Assert.Same(response, response_2);
+                IEnumerable<string> values;
+                Assert.True(httpRequestMessage.Headers.TryGetValues("Retry-Attempt", out values), "Don't set Retry-Attemp Header");
+                Assert.Equal(values.Count(), 1);
+                Assert.Equal(values.First(), 1.ToString());
+            }
+
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/RedirectHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/RedirectHandlerTests.cs
@@ -33,6 +33,16 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
+        public void RedirectHandler_Constructor()
+        {
+            using (RedirectHandler redirect = new RedirectHandler())
+            {
+                Assert.Null(redirect.InnerHandler);
+                Assert.IsType(typeof(RedirectHandler), redirect);
+            }
+        }
+
+        [Fact]
         public void RedirectHandler_HttpMessageHandlerConstructor()
         {
             Assert.NotNull(this.redirectHandler.InnerHandler);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/RetryHandlerTests.cs
@@ -37,6 +37,17 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
+        public void retryHandler_Constructor()
+        {
+            using (RetryHandler retry = new RetryHandler())
+            {
+                Assert.Null(retry.InnerHandler);
+                Assert.IsType(typeof(RetryHandler), retry);
+            }
+        }
+
+
+        [Fact]
         public void retryHandler_HttpMessageHandlerConstructor()
         {
             Assert.NotNull(retryHandler.InnerHandler);

--- a/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0-preview-20180924-03" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 


### PR DESCRIPTION
<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->


<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
Create GraphClientFactory class to offer client create instances of platform native HTTP client library that are pre-configured for making requests to Graph APIs
-Four CreateClient methods to create instances of HTTP client with different properties.
-CreatePipeline method to create middleware pipeline for the HTTP client
-Configure method to set default properties of the HTTP client
-Add non-param constructor methods to RetryHandler and RedirectHandler

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
-Requirements: https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/GraphClientFactory.md
-
-