### PR TITLE
Http provider with graph client factory

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
+++ b/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
@@ -44,8 +44,6 @@ namespace Microsoft.Graph
             {
                 using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, this.monitorUrl))
                 {
-                    await this.client.AuthenticationProvider.AuthenticateRequestAsync(httpRequestMessage).ConfigureAwait(false);
-
                     using (var responseMessage = await this.client.HttpProvider.SendAsync(httpRequestMessage).ConfigureAwait(false))
                     {
                         // The monitor service will return an Accepted status for any monitor operation that hasn't completed.

--- a/src/Microsoft.Graph.Core/Requests/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/AuthenticationHandler.cs
@@ -25,14 +25,6 @@ namespace Microsoft.Graph
 
         /// <summary>
         /// Construct a new <see cref="AuthenticationHandler"/>
-        /// </summary>
-        public AuthenticationHandler()
-        {
-
-        }
-
-        /// <summary>
-        /// Construct a new <see cref="AuthenticationHandler"/>
         /// <param name="authenticationProvider">An authentication provider to pass to <see cref="AuthenticationHandler"/> for authenticating requests.</param>
         /// </summary>
         public AuthenticationHandler(IAuthenticationProvider authenticationProvider)

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -25,14 +25,8 @@ namespace Microsoft.Graph
             IHttpProvider httpProvider = null)
         {
             this.BaseUrl = baseUrl;
-            this.AuthenticationProvider = authenticationProvider;
-            this.HttpProvider = httpProvider ?? new HttpProvider(this.AuthenticationProvider, new Serializer());
+            this.HttpProvider = httpProvider ?? new HttpProvider(authenticationProvider, new Serializer());
         }
-
-        /// <summary>
-        /// Gets the <see cref="IAuthenticationProvider"/> for authenticating requests.
-        /// </summary>
-        public IAuthenticationProvider AuthenticationProvider { get; set; }
 
         /// <summary>
         /// Gets or sets the base URL for requests of the client.

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Graph
         {
             this.BaseUrl = baseUrl;
             this.AuthenticationProvider = authenticationProvider;
-            this.HttpProvider = httpProvider ?? new HttpProvider(new Serializer());
+            this.HttpProvider = httpProvider ?? new HttpProvider(this.AuthenticationProvider, new Serializer());
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -189,16 +189,6 @@ namespace Microsoft.Graph
                     });
             }
 
-            if (this.Client.AuthenticationProvider == null)
-            {
-                throw new ServiceException(
-                    new Error
-                    {
-                        Code = ErrorConstants.Codes.InvalidRequest,
-                        Message = ErrorConstants.Messages.AuthenticationProviderMissing,
-                    });
-            }
-
             if (multipartContent != null)
             {
                 using (var request = this.GetHttpRequestMessage())
@@ -233,16 +223,6 @@ namespace Microsoft.Graph
                     {
                         Code = ErrorConstants.Codes.InvalidRequest,
                         Message = ErrorConstants.Messages.RequestUrlMissing,
-                    });
-            }
-
-            if (this.Client.AuthenticationProvider == null)
-            {
-                throw new ServiceException(
-                    new Error
-                    {
-                        Code = ErrorConstants.Codes.InvalidRequest,
-                        Message = ErrorConstants.Messages.AuthenticationProviderMissing,
                     });
             }
 

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -189,6 +189,16 @@ namespace Microsoft.Graph
                     });
             }
 
+            if (this.Client.AuthenticationProvider == null)
+            {
+                throw new ServiceException(
+                    new Error
+                    {
+                        Code = ErrorConstants.Codes.InvalidRequest,
+                        Message = ErrorConstants.Messages.AuthenticationProviderMissing,
+                    });
+            }
+
             if (multipartContent != null)
             {
                 using (var request = this.GetHttpRequestMessage())
@@ -226,6 +236,16 @@ namespace Microsoft.Graph
                     });
             }
 
+            if (this.Client.AuthenticationProvider == null)
+            {
+                throw new ServiceException(
+                    new Error
+                    {
+                        Code = ErrorConstants.Codes.InvalidRequest,
+                        Message = ErrorConstants.Messages.AuthenticationProviderMissing,
+                    });
+            }
+
             using (var request = this.GetHttpRequestMessage())
             {
                 if (serializableObject != null)
@@ -259,7 +279,23 @@ namespace Microsoft.Graph
         {
             var queryString = this.BuildQueryString();
             var request = new HttpRequestMessage(new HttpMethod(this.Method), string.Concat(this.RequestUrl, queryString));
+            this.AddHeadersToRequest(request);
             return request;
+        }
+
+        /// <summary>
+        /// Adds all of the headers from the header collection to the request.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> representation of the request.</param>
+        private void AddHeadersToRequest(HttpRequestMessage request)
+        {
+            if (this.Headers != null)
+            {
+                foreach (var header in this.Headers)
+                {
+                    request.Headers.TryAddWithoutValidation(header.Name, header.Value);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -27,6 +27,15 @@ namespace Microsoft.Graph
         /// <summary>
         /// Constructs a new <see cref="HttpProvider"/>.
         /// </summary>
+        /// <param name="serializer">A serializer for serializing and deserializing JSON objects.</param>
+        public HttpProvider(ISerializer serializer = null)
+            : this(null, (HttpMessageHandler)null, true, serializer)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="HttpProvider"/>.
+        /// </summary>
         /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> for authenticating request messages.</param>
         /// <param name="serializer">A serializer for serializing and deserializing JSON objects.</param>
         public HttpProvider(IAuthenticationProvider authenticationProvider, ISerializer serializer = null)
@@ -39,15 +48,14 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="httpClientHandler">An HTTP client handler to pass to the <see cref="HttpClient"/> for sending requests.</param>
         /// <param name="disposeHandler">Whether or not to dispose the client handler on Dispose().</param>
-        /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> for authenticating request messages.</param>
         /// <param name="serializer">A serializer for serializing and deserializing JSON objects.</param>
         /// <remarks>
         ///     By default, HttpProvider disables automatic redirects and handles redirects to preserve authentication headers. If providing
         ///     an <see cref="HttpClientHandler"/> to the constructor and enabling automatic redirects this could cause issues with authentication
         ///     over the redirect.
         /// </remarks>
-        public HttpProvider(IAuthenticationProvider authenticationProvider, HttpClientHandler httpClientHandler, bool disposeHandler, ISerializer serializer = null)
-            : this(authenticationProvider, (HttpMessageHandler)httpClientHandler, disposeHandler, serializer)
+        public HttpProvider(HttpClientHandler httpClientHandler, bool disposeHandler, ISerializer serializer = null)
+            : this(null, (HttpMessageHandler)httpClientHandler, disposeHandler, serializer)
         {
         }
 
@@ -72,6 +80,35 @@ namespace Microsoft.Graph
             };
 
             this.httpClient = GraphClientFactory.CreateClient(this.httpMessageHandler, handlers);
+        }
+
+        /// <summary>
+        /// Gets or sets the overall request timeout.
+        /// </summary>
+        public TimeSpan OverallTimeout
+        {
+            get
+            {
+                return this.httpClient.Timeout;
+            }
+
+            set
+            {
+                try
+                {
+                    this.httpClient.Timeout = value;
+                }
+                catch (InvalidOperationException exception)
+                {
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = ErrorConstants.Codes.NotAllowed,
+                            Message = ErrorConstants.Messages.OverallTimeoutCannotBeSet,
+                        },
+                        exception);
+                }
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
@@ -10,11 +10,6 @@ namespace Microsoft.Graph
     public interface IBaseClient
     {
         /// <summary>
-        /// Gets the <see cref="IAuthenticationProvider"/> for authenticating HTTP requests.
-        /// </summary>
-        IAuthenticationProvider AuthenticationProvider { get; }
-
-        /// <summary>
         /// Gets the base URL for requests of the client.
         /// </summary>
         string BaseUrl { get; }

--- a/src/Microsoft.Graph.Core/Requests/IHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/IHttpProvider.cs
@@ -20,6 +20,11 @@ namespace Microsoft.Graph
         ISerializer Serializer { get; }
 
         /// <summary>
+        /// Gets or sets the timeout interval. The default value is 100 seconds.
+        /// </summary>
+        TimeSpan OverallTimeout { get; set; }
+
+        /// <summary>
         /// Sends the request.
         /// </summary>
         /// <param name="request">The <see cref="HttpRequestMessage"/> to send.</param>

--- a/src/Microsoft.Graph.Core/Requests/IHttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/IHttpProvider.cs
@@ -20,11 +20,6 @@ namespace Microsoft.Graph
         ISerializer Serializer { get; }
 
         /// <summary>
-        /// Gets or sets the timeout interval. The default value is 100 seconds.
-        /// </summary>
-        TimeSpan OverallTimeout { get; set; }
-
-        /// <summary>
         /// Sends the request.
         /// </summary>
         /// <param name="request">The <see cref="HttpRequestMessage"/> to send.</param>

--- a/src/Microsoft.Graph.Core/Requests/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/RedirectHandler.cs
@@ -51,6 +51,15 @@ namespace Microsoft.Graph
             // check response status code 
             if (IsRedirect(response.StatusCode))
             {
+                if (response.Headers.Location == null)
+                {
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = ErrorConstants.Codes.GeneralException,
+                            Message = ErrorConstants.Messages.LocationHeaderNotSetOnRedirect,
+                        });
+                }
 
                 var redirectCount = 0;
 

--- a/src/Microsoft.Graph/Requests/UploadChunkRequest.cs
+++ b/src/Microsoft.Graph/Requests/UploadChunkRequest.cs
@@ -153,11 +153,6 @@ namespace Microsoft.Graph
                 throw new ArgumentNullException(nameof(this.RequestUrl), "Session Upload URL cannot be null or empty.");
             }
 
-            if (this.Client.AuthenticationProvider == null)
-            {
-                throw new ArgumentNullException(nameof(this.Client.AuthenticationProvider), "Client.AuthenticationProvider must not be null.");
-            }
-
             using (var request = this.GetHttpRequestMessage())
             {
                 request.Content = new StreamContent(stream);

--- a/tests/Microsoft.Graph.Core.Test/Mocks/MockAuthenticationProvider.cs
+++ b/tests/Microsoft.Graph.Core.Test/Mocks/MockAuthenticationProvider.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Graph.Core.Test.Mocks
 {
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading.Tasks;
 
     using Moq;
@@ -18,6 +19,7 @@ namespace Microsoft.Graph.Core.Test.Mocks
 
             this.Setup(
                 provider => provider.AuthenticateRequestAsync(It.IsAny<HttpRequestMessage>()))
+                .Callback<HttpRequestMessage>(r => r.Headers.Authorization = new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, "Token"))
                 .Returns(Task.FromResult(0));
         }
     }

--- a/tests/Microsoft.Graph.Core.Test/Requests/AsyncMonitorTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/AsyncMonitorTests.cs
@@ -43,7 +43,6 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             this.client = new Mock<IBaseClient>(MockBehavior.Strict);
             this.client.SetupAllProperties();
-            this.client.SetupGet(client => client.AuthenticationProvider).Returns(this.authenticationProvider.Object);
             this.client.SetupGet(client => client.HttpProvider).Returns(this.httpProvider.Object);
 
             this.progress = new MockProgress();
@@ -94,16 +93,6 @@ namespace Microsoft.Graph.Core.Test.Requests
                 Assert.IsTrue(called, "Progress not called");
                 Assert.IsNotNull(item, "No item returned.");
                 Assert.AreEqual("id", item.Id, "Unexpected item returned.");
-                
-                this.authenticationProvider.Verify(
-                    provider => provider.AuthenticateRequestAsync(
-                        It.Is<HttpRequestMessage>(message => message.RequestUri.ToString().Equals(AsyncMonitorTests.monitorUrl))),
-                    Times.Once);
-
-                this.authenticationProvider.Verify(
-                    provider => provider.AuthenticateRequestAsync(
-                        It.Is<HttpRequestMessage>(message => message.RequestUri.ToString().Equals(AsyncMonitorTests.itemUrl))),
-                    Times.Once);
             }
         }
 

--- a/tests/Microsoft.Graph.Core.Test/Requests/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/AuthenticationHandlerTests.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Graph.Core.Test.Requests
         }
 
         [TestMethod]
-        public void AuthHandler_DefaultConstructor()
+        public void AuthHandler_AuthProviderConstructor()
         {
-            using (AuthenticationHandler auth = new AuthenticationHandler())
+            using (AuthenticationHandler auth = new AuthenticationHandler(mockAuthenticationProvider.Object))
             {
                 Assert.IsNull(auth.InnerHandler, "Http message handler initialized");
-                Assert.IsNull(auth.AuthenticationProvider, "Authentication provider initialized");
+                Assert.IsNotNull(auth.AuthenticationProvider, "Authentication provider initialized");
                 Assert.IsInstanceOfType(auth, typeof(AuthenticationHandler), "Unexpected authentication handler set");
             }
         }

--- a/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
@@ -23,12 +23,13 @@ namespace Microsoft.Graph.Core.Test.Requests
         private HttpProvider httpProvider;
         private MockSerializer serializer = new MockSerializer();
         private TestHttpMessageHandler testHttpMessageHandler;
+        private MockAuthenticationProvider authProvider = new MockAuthenticationProvider();
 
         [TestInitialize]
         public void Setup()
         {
             this.testHttpMessageHandler = new TestHttpMessageHandler();
-            this.httpProvider = new HttpProvider(this.testHttpMessageHandler, true, this.serializer.Object);
+            this.httpProvider = new HttpProvider(authProvider.Object, this.testHttpMessageHandler, true, this.serializer.Object);
         }
 
         [TestCleanup]
@@ -42,8 +43,9 @@ namespace Microsoft.Graph.Core.Test.Requests
         {
             var timeout = TimeSpan.FromSeconds(200);
             var cacheHeader = new CacheControlHeaderValue();
-            using (var defaultHttpProvider = new HttpProvider(null) { CacheControlHeader = cacheHeader, OverallTimeout = timeout })
+            using (var defaultHttpProvider = new HttpProvider(authProvider.Object, null))
             {
+                GraphClientFactory.Configure(defaultHttpProvider.httpClient, timeout, null, cacheHeader);
                 Assert.IsFalse(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoCache, "NoCache true.");
                 Assert.IsFalse(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoStore, "NoStore true.");
 
@@ -57,7 +59,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         public void HttpProvider_CustomHttpClientHandler()
         {
             using (var httpClientHandler = new HttpClientHandler())
-            using (var httpProvider = new HttpProvider(httpClientHandler, false, null))
+            using (var httpProvider = new HttpProvider(authProvider.Object, httpClientHandler, false, null))
             {
                 Assert.AreEqual(httpClientHandler, httpProvider.httpMessageHandler, "Unexpected message handler set.");
                 Assert.IsFalse(httpProvider.disposeHandler, "Dispose handler set to true.");
@@ -67,7 +69,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void HttpProvider_DefaultConstructor()
         {
-            using (var defaultHttpProvider = new HttpProvider())
+            using (var defaultHttpProvider = new HttpProvider(authProvider.Object))
             {
                 Assert.IsTrue(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoCache, "NoCache false.");
                 Assert.IsTrue(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoStore, "NoStore false.");
@@ -86,7 +88,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         public void HttpProvider_HttpMessageHandlerConstructor()
         {
            
-            using (var httpProvider = new HttpProvider(this.testHttpMessageHandler, true, null))
+            using (var httpProvider = new HttpProvider(authProvider.Object, this.testHttpMessageHandler, true, null))
             {
                 Assert.IsNotNull(httpProvider.httpMessageHandler, "HttpMessageHandler not initialized");
                 Assert.AreEqual(httpProvider.httpMessageHandler, this.testHttpMessageHandler, "Unexpected message handler set.");
@@ -109,7 +111,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             try
             {
-                this.httpProvider.OverallTimeout = new TimeSpan(0, 0, 30);
+                GraphClientFactory.Configure(this.httpProvider.httpClient, new TimeSpan(0, 0, 30), null, null);
             }
             catch (ServiceException serviceException)
             {
@@ -146,7 +148,7 @@ namespace Microsoft.Graph.Core.Test.Requests
                 this.httpProvider.Dispose();
 
                 var clientException = new Exception();
-                this.httpProvider = new HttpProvider(new ExceptionHttpMessageHandler(clientException), /* disposeHandler */ true, null);
+                this.httpProvider = new HttpProvider(authProvider.Object, new ExceptionHttpMessageHandler(clientException), /* disposeHandler */ true, null);
 
                 try
                 {
@@ -172,7 +174,7 @@ namespace Microsoft.Graph.Core.Test.Requests
                 this.httpProvider.Dispose();
 
                 var clientException = new TaskCanceledException();
-                this.httpProvider = new HttpProvider(new ExceptionHttpMessageHandler(clientException), /* disposeHandler */ true, null);
+                this.httpProvider = new HttpProvider(authProvider.Object, new ExceptionHttpMessageHandler(clientException), /* disposeHandler */ true, null);
 
                 try
                 {
@@ -182,7 +184,7 @@ namespace Microsoft.Graph.Core.Test.Requests
                 {
                     Assert.IsTrue(exception.IsMatch(ErrorConstants.Codes.Timeout), "Unexpected error code returned.");
                     Assert.AreEqual(ErrorConstants.Messages.RequestTimedOut, exception.Error.Message, "Unexpected error message.");
-                    Assert.AreEqual(clientException, exception.InnerException, "Inner exception not set.");
+                    Assert.AreEqual(clientException.Message, exception.InnerException.Message, "Inner exception not set.");
 
                     throw;
                 }
@@ -225,9 +227,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             using (var redirectResponseMessage = new HttpResponseMessage())
             using (var finalResponseMessage = new HttpResponseMessage())
             {
-                httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("bearer", "token");
                 httpRequestMessage.Headers.Add("testHeader", "testValue");
-                httpRequestMessage.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true, NoStore = true };
 
                 redirectResponseMessage.StatusCode = HttpStatusCode.Redirect;
                 redirectResponseMessage.Headers.Location = new Uri("https://localhost/redirect");
@@ -238,7 +238,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
                 var returnedResponseMessage = await this.httpProvider.SendAsync(httpRequestMessage);
 
-                Assert.AreEqual(3, finalResponseMessage.RequestMessage.Headers.Count(), "Unexpected number of headers on redirect request message.");
+                Assert.AreEqual(4, finalResponseMessage.RequestMessage.Headers.Count(), "Unexpected number of headers on redirect request message.");
                 
                 foreach (var header in httpRequestMessage.Headers)
                 {
@@ -265,21 +265,19 @@ namespace Microsoft.Graph.Core.Test.Requests
                 redirectResponseMessage.StatusCode = HttpStatusCode.Redirect;
                 redirectResponseMessage.Headers.Location = new Uri("https://localhost/redirect");
                 tooManyRedirectsResponseMessage.StatusCode = HttpStatusCode.Redirect;
+                tooManyRedirectsResponseMessage.Headers.Location = new Uri("https://localhost");
 
                 redirectResponseMessage.RequestMessage = httpRequestMessage;
 
                 this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), redirectResponseMessage);
                 this.testHttpMessageHandler.AddResponseMapping(redirectResponseMessage.Headers.Location.ToString(), tooManyRedirectsResponseMessage);
 
-                httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, "ticket");
-
                 try
                 {
-                    await this.httpProvider.HandleRedirect(
-                        redirectResponseMessage,
+                    await this.httpProvider.SendAsync(
+                        httpRequestMessage,
                         HttpCompletionOption.ResponseContentRead,
-                        CancellationToken.None,
-                        5);
+                        CancellationToken.None);
                 }
                 catch (ServiceException exception)
                 {

--- a/tests/Microsoft.Graph.Core.Test/Requests/RequestTestBase.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/RequestTestBase.cs
@@ -13,21 +13,23 @@ namespace Microsoft.Graph.Core.Test.Requests
     public class RequestTestBase
     {
         protected string baseUrl = "https://localhost/v1.0";
-
-        protected MockAuthenticationProvider authenticationProvider;
-        protected MockHttpProvider httpProvider;
+        protected HttpProvider xhttpProvider;
         protected HttpResponseMessage httpResponseMessage;
         protected IBaseClient baseClient;
         protected MockSerializer serializer;
+        protected TestHttpMessageHandler testHttpMessageHandler;
+        protected MockHttpProvider httpProvider;
+        protected MockAuthenticationProvider authenticationProvider = new MockAuthenticationProvider();
 
         [TestInitialize]
         public void Setup()
         {
-            this.authenticationProvider = new MockAuthenticationProvider();
             this.serializer = new MockSerializer();
             this.httpResponseMessage = new HttpResponseMessage();
+            this.testHttpMessageHandler = new TestHttpMessageHandler();
+            //this.httpProvider = new HttpProvider(authenticationProvider.Object, this.testHttpMessageHandler, true, this.serializer.Object);
             this.httpProvider = new MockHttpProvider(this.httpResponseMessage, this.serializer.Object);
-            
+
             this.baseClient = new BaseClient(
                 this.baseUrl,
                 this.authenticationProvider.Object,

--- a/tests/Microsoft.Graph.Core.Test/TestModels/CustomRequest.cs
+++ b/tests/Microsoft.Graph.Core.Test/TestModels/CustomRequest.cs
@@ -8,14 +8,9 @@ namespace Microsoft.Graph.Core.Test.TestModels
 
     public class CustomRequest : BaseRequest
     {
-        internal static readonly string SdkHeaderName = "Name";
-        internal static readonly string SdkHeaderValue = "Value";
-
         public CustomRequest(string baseUrl, IBaseClient baseClient, IEnumerable<Option> options = null)
             : base(baseUrl, baseClient, options)
         {
-            this.sdkVersionHeaderName = CustomRequest.SdkHeaderName;
-            this.sdkVersionHeaderValue = CustomRequest.SdkHeaderValue;
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AsyncMonitorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AsyncMonitorTests.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             this.client = new Mock<IBaseClient>(MockBehavior.Strict);
             this.client.SetupAllProperties();
-            this.client.SetupGet(client => client.AuthenticationProvider).Returns(this.authenticationProvider.Object);
             this.client.SetupGet(client => client.HttpProvider).Returns(this.httpProvider.Object);
 
             this.progress = new MockProgress();
@@ -92,16 +91,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 Assert.True(called);
                 Assert.NotNull(item);
                 Assert.Equal("id", item.Id);
-
-                this.authenticationProvider.Verify(
-                    provider => provider.AuthenticateRequestAsync(
-                        It.Is<HttpRequestMessage>(message => message.RequestUri.ToString().Equals(AsyncMonitorTests.monitorUrl))),
-                    Times.Once);
-
-                this.authenticationProvider.Verify(
-                    provider => provider.AuthenticateRequestAsync(
-                        It.Is<HttpRequestMessage>(message => message.RequestUri.ToString().Equals(AsyncMonitorTests.itemUrl))),
-                    Times.Once);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AuthenticationHandlerTests.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
-        public void AuthHandler_DefaultConstructor()
+        public void AuthHandler_AuthProviderConstructor()
         {
-            using (AuthenticationHandler auth = new AuthenticationHandler())
+            using (AuthenticationHandler auth = new AuthenticationHandler(mockAuthenticationProvider.Object))
             {
                 Assert.Null(auth.InnerHandler);
-                Assert.Null(auth.AuthenticationProvider);
+                Assert.NotNull(auth.AuthenticationProvider);
                 Assert.IsType(typeof(AuthenticationHandler), auth);
             }
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -77,11 +77,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 httpRequestMessage.RequestUri.GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Port, UriFormat.Unescaped));
             Assert.Equal("value1", httpRequestMessage.Headers.GetValues("header1").First());
             Assert.Equal("value2", httpRequestMessage.Headers.GetValues("header2").First());
-
-            var expectedVersion = typeof(BaseRequest).GetTypeInfo().Assembly.GetName().Version;
-            Assert.Equal(
-                string.Format("Graph-dotnet-{0}.{1}.{2}", expectedVersion.Major, expectedVersion.Minor, expectedVersion.Build),
-                httpRequestMessage.Headers.GetValues(CoreConstants.Headers.SdkVersionHeaderName).First());
         }
 
         [Fact]
@@ -95,29 +90,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             Assert.Equal(HttpMethod.Delete, httpRequestMessage.Method);
             Assert.Equal(requestUrl,
                 httpRequestMessage.RequestUri.GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Port, UriFormat.Unescaped));
-            Assert.Equal(1, httpRequestMessage.Headers.Count());
-
-            var expectedVersion = typeof(BaseRequest).GetTypeInfo().Assembly.GetName().Version;
-            Assert.Equal(
-                string.Format("Graph-dotnet-{0}.{1}.{2}", expectedVersion.Major, expectedVersion.Minor, expectedVersion.Build),
-                httpRequestMessage.Headers.GetValues(CoreConstants.Headers.SdkVersionHeaderName).First());
-        }
-
-        [Fact]
-        public void GetWebRequest_OverrideCustomTelemetryHeader()
-        {
-            var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
-
-            var baseRequest = new CustomRequest(requestUrl, this.baseClient);
-
-            var httpRequestMessage = baseRequest.GetHttpRequestMessage();
-
-            Assert.Equal(
-                CustomRequest.SdkHeaderValue,
-                httpRequestMessage.Headers.GetValues(CustomRequest.SdkHeaderName).First());
-
-            Assert.False(
-                httpRequestMessage.Headers.Contains(CoreConstants.Headers.SdkVersionHeaderName));
+            Assert.Equal(0, httpRequestMessage.Headers.Count());
         }
 
         [Fact]
@@ -155,8 +128,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
                 Assert.NotNull(responseItem);
                 Assert.Equal(expectedResponseItem.Id, responseItem.Id);
-
-                this.authenticationProvider.Verify(provider => provider.AuthenticateRequestAsync(It.IsAny<HttpRequestMessage>()), Times.Once);
             }
         }
 
@@ -207,8 +178,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     .Returns(string.Empty);
 
                 await baseRequest.SendAsync("string", CancellationToken.None);
-
-                this.authenticationProvider.Verify(provider => provider.AuthenticateRequestAsync(It.IsAny<HttpRequestMessage>()), Times.Once);
             }
         }
 
@@ -239,8 +208,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 var instance = await baseRequest.SendAsync<DerivedTypeClass>("string", CancellationToken.None);
 
                 Assert.Null(instance);
-
-                this.authenticationProvider.Verify(provider => provider.AuthenticateRequestAsync(It.IsAny<HttpRequestMessage>()), Times.Once);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -276,7 +276,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 HttpClient client = GraphClientFactory.CreateClient(handlers);
             }
-            catch (Exception exception)
+            catch (ArgumentException exception)
             {
                 Assert.IsType(typeof(ArgumentException), exception);
                 Assert.Equal(exception.Message, String.Format("DelegatingHandler array has unexpected InnerHandler. {0} has unexpected InnerHandler.", handlers[handlers.Length - 1]));

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     {
         private DelegatingHandler[] handlers = new DelegatingHandler[3];
         private MockRedirectHandler testHttpMessageHandler;
+        private MockAuthenticationProvider mockAuthenticationProvider = new MockAuthenticationProvider();
 
 
         public GraphClientFactoryTests()
@@ -27,7 +28,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             this.testHttpMessageHandler = new MockRedirectHandler();
             handlers[0] = new RetryHandler();
             handlers[1] = new RedirectHandler();
-            handlers[2] = new AuthenticationHandler();
+            handlers[2] = new AuthenticationHandler(mockAuthenticationProvider.Object);
         }
 
         public void Dispose()
@@ -209,7 +210,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
-        public async Task SendRequest_UnauthorizedWithNoAuthenticationProvider()
+        public async Task SendRequest_UnauthorizedWithNullAuthenticationProvider()
         {
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, "https://example.com/bar");
             httpRequestMessage.Content = new StringContent("Hello World");
@@ -219,11 +220,21 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, okResponse);
 
-            using (HttpClient client = GraphClientFactory.CreateClient(testHttpMessageHandler, handlers))
+            handlers[2] = new AuthenticationHandler(null);
+
+            try
             {
-                var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
-                Assert.Same(response, unauthorizedResponse);
-                Assert.Same(response.RequestMessage, httpRequestMessage);
+                using (HttpClient client = GraphClientFactory.CreateClient(testHttpMessageHandler, handlers))
+                {
+                    var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
+                    Assert.Same(response, unauthorizedResponse);
+                    Assert.Same(response.RequestMessage, httpRequestMessage);
+                }
+            }
+            catch (Exception exception)
+            {
+                Assert.IsType(typeof(ServiceException), exception);
+                Assert.Contains(ErrorConstants.Messages.AuthenticationProviderMissing, exception.Message);
             }
         }
 
@@ -237,8 +248,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var okResponse = new HttpResponseMessage(HttpStatusCode.OK);
 
             testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, okResponse);
-
-            handlers[2] = new AuthenticationHandler(new MockAuthenticationProvider().Object);
 
             using (HttpClient client = GraphClientFactory.CreateClient(testHttpMessageHandler, handlers))
             {
@@ -267,7 +276,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 HttpClient client = GraphClientFactory.CreateClient(handlers);
             }
-            catch (ArgumentException exception)
+            catch (Exception exception)
             {
                 Assert.IsType(typeof(ArgumentException), exception);
                 Assert.Equal(exception.Message, String.Format("DelegatingHandler array has unexpected InnerHandler. {0} has unexpected InnerHandler.", handlers[handlers.Length - 1]));

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/CustomRequest.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/CustomRequest.cs
@@ -11,14 +11,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels
 {
     public class CustomRequest : BaseRequest
     {
-        internal static readonly string SdkHeaderName = "Name";
-        internal static readonly string SdkHeaderValue = "Value";
-
         public CustomRequest(string baseUrl, IBaseClient baseClient, IEnumerable<Option> options = null)
             : base(baseUrl, baseClient, options)
         {
-            this.sdkVersionHeaderName = CustomRequest.SdkHeaderName;
-            this.sdkVersionHeaderValue = CustomRequest.SdkHeaderValue;
         }
     }
 }

--- a/tests/Microsoft.Graph.Test/Requests/Functional/ExcelTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/ExcelTests.cs
@@ -502,9 +502,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
 
                 HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Get, urlToGetImageFromChart);
 
-                // Authenticate (add access token) our HttpRequestMessage
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                 // Send the request and get the response.
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);
 

--- a/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
@@ -48,22 +48,22 @@ namespace Microsoft.Graph.Test.Requests.Functional
         /// I set the autoresponder latency to 10 seconds, and the client's timeout to 7 sec (2 minutes).
         /// You'll need to remove the Ignore attribute to run this as well. 
         /// </summary>
-        [TestMethod]
-        [Ignore]
-        public async Async.Task ManualAdHocTimeoutTest()
-        {
-            graphClient.HttpProvider.OverallTimeout = new TimeSpan(0, 0, 7);
-            try
-            {
-                User me = await graphClient.Me.Request().GetAsync();
+        //[TestMethod]
+        //[Ignore]
+        //public async Async.Task ManualAdHocTimeoutTest()
+        //{
+        //    graphClient.HttpProvider.OverallTimeout = new TimeSpan(0, 0, 7);
+        //    try
+        //    {
+        //        User me = await graphClient.Me.Request().GetAsync();
 
-                Assert.Fail("Expected an exception if this was setup correctly.");
-            }
-            catch (ServiceException ex)
-            {
-                Assert.IsInstanceOfType(ex.InnerException, typeof(Async.TaskCanceledException), "Unexpected inner exception thrown.");
-            }
-        }
+        //        Assert.Fail("Expected an exception if this was setup correctly.");
+        //    }
+        //    catch (ServiceException ex)
+        //    {
+        //        Assert.IsInstanceOfType(ex.InnerException, typeof(Async.TaskCanceledException), "Unexpected inner exception thrown.");
+        //    }
+        //}
     }
 }
 

--- a/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
@@ -48,22 +48,22 @@ namespace Microsoft.Graph.Test.Requests.Functional
         /// I set the autoresponder latency to 10 seconds, and the client's timeout to 7 sec (2 minutes).
         /// You'll need to remove the Ignore attribute to run this as well. 
         /// </summary>
-        //[TestMethod]
-        //[Ignore]
-        //public async Async.Task ManualAdHocTimeoutTest()
-        //{
-        //    graphClient.HttpProvider.OverallTimeout = new TimeSpan(0, 0, 7);
-        //    try
-        //    {
-        //        User me = await graphClient.Me.Request().GetAsync();
+        [TestMethod]
+        [Ignore]
+        public async Async.Task ManualAdHocTimeoutTest()
+        {
+            // graphClient.HttpProvider.OverallTimeout = new TimeSpan(0, 0, 7);
+            try
+            {
+                User me = await graphClient.Me.Request().GetAsync();
 
-        //        Assert.Fail("Expected an exception if this was setup correctly.");
-        //    }
-        //    catch (ServiceException ex)
-        //    {
-        //        Assert.IsInstanceOfType(ex.InnerException, typeof(Async.TaskCanceledException), "Unexpected inner exception thrown.");
-        //    }
-        //}
+                Assert.Fail("Expected an exception if this was setup correctly.");
+            }
+            catch (ServiceException ex)
+            {
+                Assert.IsInstanceOfType(ex.InnerException, typeof(Async.TaskCanceledException), "Unexpected inner exception thrown.");
+            }
+        }
     }
 }
 

--- a/tests/Microsoft.Graph.Test/Requests/Functional/OneNoteTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/OneNoteTests.cs
@@ -358,9 +358,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                 hrm.Content = new StringContent(htmlBody, System.Text.Encoding.UTF8, "text/html");
 
-                // Authenticate (add access token) our HttpRequestMessage
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                 // Send the request and get the response.
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);
 
@@ -426,9 +423,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     // Create the request message and add the content.
                     HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                     hrm.Content = body;
-
-                    // Authenticate (add access token to) our HttpRequestMessage
-                    await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
 
                     // Send the request and get the response.
                     response = await graphClient.HttpProvider.SendAsync(hrm);
@@ -516,9 +510,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                     hrm.Content = multiPartContent;
 
-                    // Authenticate (add access token to) our HttpRequestMessage
-                    await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                     // Send the request and get the response.
                     response = await graphClient.HttpProvider.SendAsync(hrm);
                 }
@@ -603,9 +594,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 string updateBodyCommandString = graphClient.HttpProvider.Serializer.SerializeObject(commands);
                 hrm.Content = new StringContent(updateBodyCommandString);
                 hrm.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-
-                // Authenticate (add access token to) our request
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
 
                 // Send the request and get the response.
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);

--- a/tests/Microsoft.Graph.Test/Requests/Functional/ReportTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/ReportTests.cs
@@ -24,9 +24,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 string getOffice365ActiveUserCountsRequestUrl = graphClient.Reports.GetOffice365ActiveUserCounts("D7").Request().RequestUrl;
                 HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Get, getOffice365ActiveUserCountsRequestUrl);
 
-                // Inject the access token into the request.
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                 // Send the request and get the response. It will automatically follow the redirect to get the Report file.
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);
 

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
@@ -119,9 +119,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 string requestUrlToGetSiteRootInfo = String.Format("{0}{1}", graphClient.Sites.Request().RequestUrl, "/root");
                 HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Get, requestUrlToGetSiteRootInfo);
 
-                // Authenticate (add access token) to our HttpRequestMessage
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);
 
                 Site site;


### PR DESCRIPTION
<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- **HttpProvider** uses **GraphClientFactory** to create a **HttpClient** that has **RedirectHandler**, **RetryHandler** & **AuthenticationHandler** delegating handlers.
- Updates **HttpProvider** to accept **AuthenticationProvider** in it's constructors because **AuthorizationHandler** depends on it.
- Removes setting of **cache control header, telemetry header & timeout** from **BaseRequest** & **HttpProvider** since it's handled by **GraphClientFactory**.
- Removes authentication of requests using **auhtenticationProvider** from **BaseRequest** since **AuthorizationHandler** handles this.
- Removes redirect handling from **HttpProvider** since **RedirectHandler** handles the same.
- Adds null check for response location header in **RedirectHandler** before issuing a redirect.
- Updates test cases to consider above changes.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- MSGraph SDK design https://github.com/microsoftgraph/msgraph-sdk-design
- GraphClientFactory design https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/GraphClientFactory.md
