### PR TITLE
Updated to GraphClientFactory

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -13,9 +13,10 @@
     <PackageId>Microsoft.Graph.Core</PackageId>
     <PackageTags>Microsoft Office365;Graph;GraphServiceClient;Outlook;OneDrive;AzureAD;GraphAPI;Productivity;SharePoint;Intune;SDK</PackageTags>
     <PackageReleaseNotes>
-December 2018 Release Summary (version 1.13.0)
+January 2019 Release Summary (version 1.13.0-preview.2)
 
 - Authentication handler added.
+- Removed Newtonsoft.Json package reference upper bound limitation.
     </PackageReleaseNotes>
     <PackageProjectUrl>https://developer.microsoft.com/graph</PackageProjectUrl>
     <PackageLicenseUrl>http://aka.ms/devservicesagreement</PackageLicenseUrl>
@@ -35,7 +36,7 @@ December 2018 Release Summary (version 1.13.0)
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>1.13.0-preview</Version>
+    <Version>1.13.0-preview.2</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.1|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.1\Microsoft.Graph.Core.xml</DocumentationFile>
@@ -54,7 +55,7 @@ December 2018 Release Summary (version 1.13.0)
     <Reference Include="System.Net.Http" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Newtonsoft.Json" Version="[6.0.1,12)" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
+++ b/src/Microsoft.Graph.Core/Requests/AsyncMonitor.cs
@@ -44,8 +44,6 @@ namespace Microsoft.Graph
             {
                 using (var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, this.monitorUrl))
                 {
-                    await this.client.AuthenticationProvider.AuthenticateRequestAsync(httpRequestMessage).ConfigureAwait(false);
-
                     using (var responseMessage = await this.client.HttpProvider.SendAsync(httpRequestMessage).ConfigureAwait(false))
                     {
                         // The monitor service will return an Accepted status for any monitor operation that hasn't completed.

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -25,14 +25,8 @@ namespace Microsoft.Graph
             IHttpProvider httpProvider = null)
         {
             this.BaseUrl = baseUrl;
-            this.AuthenticationProvider = authenticationProvider;
-            this.HttpProvider = httpProvider ?? new HttpProvider(new Serializer());
+            this.HttpProvider = httpProvider ?? new HttpProvider(authenticationProvider, new Serializer());
         }
-
-        /// <summary>
-        /// Gets the <see cref="IAuthenticationProvider"/> for authenticating requests.
-        /// </summary>
-        public IAuthenticationProvider AuthenticationProvider { get; set; }
 
         /// <summary>
         /// Gets or sets the base URL for requests of the client.

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -20,11 +20,6 @@ namespace Microsoft.Graph
     /// </summary>
     public class BaseRequest : IBaseRequest
     {
-        /// The key for the SDK version header.
-        protected string sdkVersionHeaderName;
-        /// The value for the SDK version header.
-        protected string sdkVersionHeaderValue;
-
         /// <summary>
         /// Constructs a new <see cref="BaseRequest"/>.
         /// </summary>
@@ -42,9 +37,6 @@ namespace Microsoft.Graph
             this.QueryOptions = new List<QueryOption>();
 
             this.RequestUrl = this.InitializeUrl(requestUrl);
-
-            this.sdkVersionHeaderName = CoreConstants.Headers.SdkVersionHeaderName;
-            this.SdkVersionHeaderPrefix = "Graph";
 
             if (options != null)
             {
@@ -91,11 +83,6 @@ namespace Microsoft.Graph
         /// Gets the URL for the request, without query string.
         /// </summary>
         public string RequestUrl { get; internal set; }
-        
-        /// <summary>
-        /// Gets or sets the telemetry header prefix for requests.
-        /// </summary>
-        protected string SdkVersionHeaderPrefix { get; set; }
 
         /// <summary>
         /// Sends the request.
@@ -202,22 +189,10 @@ namespace Microsoft.Graph
                     });
             }
 
-            if (this.Client.AuthenticationProvider == null)
-            {
-                throw new ServiceException(
-                    new Error
-                    {
-                        Code = ErrorConstants.Codes.InvalidRequest,
-                        Message = ErrorConstants.Messages.AuthenticationProviderMissing,
-                    });
-            }
-
             if (multipartContent != null)
             {
                 using (var request = this.GetHttpRequestMessage())
                 {
-                    await this.AuthenticateRequest(request).ConfigureAwait(false);
-
                     request.Content = multipartContent;
 
                     return await this.Client.HttpProvider.SendAsync(request, completionOption, cancellationToken).ConfigureAwait(false);
@@ -251,20 +226,8 @@ namespace Microsoft.Graph
                     });
             }
 
-            if (this.Client.AuthenticationProvider == null)
-            {
-                throw new ServiceException(
-                    new Error
-                    {
-                        Code = ErrorConstants.Codes.InvalidRequest,
-                        Message = ErrorConstants.Messages.AuthenticationProviderMissing,
-                    });
-            }
-
             using (var request = this.GetHttpRequestMessage())
             {
-                await this.AuthenticateRequest(request).ConfigureAwait(false);
-
                 if (serializableObject != null)
                 {
                     var inputStream = serializableObject as Stream;
@@ -296,10 +259,23 @@ namespace Microsoft.Graph
         {
             var queryString = this.BuildQueryString();
             var request = new HttpRequestMessage(new HttpMethod(this.Method), string.Concat(this.RequestUrl, queryString));
-
             this.AddHeadersToRequest(request);
-
             return request;
+        }
+
+        /// <summary>
+        /// Adds all of the headers from the header collection to the request.
+        /// </summary>
+        /// <param name="request">The <see cref="HttpRequestMessage"/> representation of the request.</param>
+        private void AddHeadersToRequest(HttpRequestMessage request)
+        {
+            if (this.Headers != null)
+            {
+                foreach (var header in this.Headers)
+                {
+                    request.Headers.TryAddWithoutValidation(header.Name, header.Value);
+                }
+            }
         }
 
         /// <summary>
@@ -338,47 +314,6 @@ namespace Microsoft.Graph
             }
 
             return null;
-        }
-
-        /// <summary>
-        /// Adds all of the headers from the header collection to the request.
-        /// </summary>
-        /// <param name="request">The <see cref="HttpRequestMessage"/> representation of the request.</param>
-        private void AddHeadersToRequest(HttpRequestMessage request)
-        {
-            if (this.Headers != null)
-            {
-                foreach (var header in this.Headers)
-                {
-                    request.Headers.TryAddWithoutValidation(header.Name, header.Value);
-                }
-            }
-
-            if (string.IsNullOrEmpty(this.sdkVersionHeaderValue))
-            {
-                var assemblyVersion = this.GetType().GetTypeInfo().Assembly.GetName().Version;
-                this.sdkVersionHeaderValue = string.Format(
-                    CoreConstants.Headers.SdkVersionHeaderValueFormatString,
-                    this.SdkVersionHeaderPrefix,
-                    assemblyVersion.Major,
-                    assemblyVersion.Minor,
-                    assemblyVersion.Build);
-            }
-
-            // Append SDK version header for telemetry
-            request.Headers.Add(
-                this.sdkVersionHeaderName,
-                this.sdkVersionHeaderValue);
-        }
-
-        /// <summary>
-        /// Adds the authentication header to the request.
-        /// </summary>
-        /// <param name="request">The <see cref="HttpRequestMessage"/> representation of the request.</param>
-        /// <returns>The task to await.</returns>
-        private Task AuthenticateRequest(HttpRequestMessage request)
-        {
-            return this.Client.AuthenticationProvider.AuthenticateRequestAsync(request);
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Graph
                 pipeline = CreatePipeline(CreateDefaultHandlers(), DefaultHttpHandler());
             } else
             {
-                pipeline = CreatePipeline(handlers,DefaultHttpHandler());
+                pipeline = CreatePipeline(handlers, DefaultHttpHandler());
             }
 
             HttpClient client = new HttpClient(pipeline);

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Graph
                 pipeline = CreatePipeline(CreateDefaultHandlers(), DefaultHttpHandler());
             } else
             {
-                pipeline = CreatePipeline(handlers, DefaultHttpHandler());
+                pipeline = CreatePipeline(handlers,DefaultHttpHandler());
             }
 
             HttpClient client = new HttpClient(pipeline);

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -11,14 +11,14 @@ namespace Microsoft.Graph
     using System.Reflection;
     using System.Net.Http.Headers;
 
-   
+
     /// <summary>
     /// GraphClientFactory class to create the HTTP client
     /// </summary>
-    public static class GraphClientFactory
+    internal static class GraphClientFactory
     {
 
-        
+
         /// The key for the SDK version header.
         private static readonly string SdkVersionHeaderName = CoreConstants.Headers.SdkVersionHeaderName;
 
@@ -58,13 +58,13 @@ namespace Microsoft.Graph
         public const string Germany_Cloud = "Germany";
 
         /// <summary>
-        /// Proxy to be used with created clients 
+        /// Proxy to be used with created clients
         /// </summary>
         public static IWebProxy Proxy { get; set; }
 
         /// <summary>
         /// DefaultHandler is a Func that returns the HttpMessageHandler for actually making the HTTP calls.
-        /// The default implementation returns a new instance of HttpClientHandler for each HttpClient. 
+        /// The default implementation returns a new instance of HttpClientHandler for each HttpClient.
         /// </summary>
         public static Func<HttpMessageHandler> DefaultHttpHandler = () => {
             return new HttpClientHandler
@@ -72,17 +72,17 @@ namespace Microsoft.Graph
                 Proxy = Proxy
             };
         };
-            
+
 
         /// <summary>
         /// Creates a new <see cref="HttpClient"/> instance configured with the handlers provided and with the
         /// provided <paramref name="innerHandler"/> as the innermost handler.
         /// </summary>
         /// <param name="innerHandler">The inner handler represents the destination of the HTTP message channel.</param>
-        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as an 
-        /// <see cref="HttpRequestMessage"/> travels from the <see cref="HttpClient"/> to the network and an 
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as an
+        /// <see cref="HttpRequestMessage"/> travels from the <see cref="HttpClient"/> to the network and an
         /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
-        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for
         /// an outbound request message but last for an inbound response message.</param>
         /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
         public static HttpClient Create(string version = "v1.0", string nationalCloud = Global_Cloud, IEnumerable<DelegatingHandler> handlers = null)
@@ -113,7 +113,7 @@ namespace Microsoft.Graph
             return new List<DelegatingHandler> {
                 new RetryHandler(),
                 new RedirectHandler()
-            }; 
+            };
         }
 
         private static Uri DetermineBaseAddress(string nationalCloud, string version)
@@ -127,16 +127,16 @@ namespace Microsoft.Graph
             return new Uri(cloudAddress);
 
         }
-               
+
         /// <summary>
         /// Creates an instance of an <see cref="HttpMessageHandler"/> using the <see cref="DelegatingHandler"/> instances
         /// provided by <paramref name="handlers"/>. The resulting pipeline can be used to manually create <see cref="HttpClient"/>
         /// or <see cref="HttpMessageInvoker"/> instances with customized message handlers.
         /// </summary>
         /// <param name="innerHandler">The inner handler represents the destination of the HTTP message channel.</param>
-        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as part 
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as part
         /// of sending an <see cref="HttpRequestMessage"/> and receiving an <see cref="HttpResponseMessage"/>.
-        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for 
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for
         /// an outbound request message but last for an inbound response message.</param>
         /// <returns>The HTTP message channel.</returns>
         public static HttpMessageHandler CreatePipeline(IEnumerable<DelegatingHandler> handlers, HttpMessageHandler innerHandler = null )

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Graph
                 new AuthenticationHandler(authenticationProvider)
             };
 
-            GraphClientFactory.DefaultHttpHandler = () => httpMessageHandler;
+            GraphClientFactory.DefaultHttpHandler = () => this.httpMessageHandler;
             this.httpClient = GraphClientFactory.Create("v1.0", GraphClientFactory.Global_Cloud, handlers);
         }
 

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -79,7 +79,24 @@ namespace Microsoft.Graph
                 new AuthenticationHandler(authenticationProvider)
             };
 
-            this.httpClient = GraphClientFactory.CreateClient(this.httpMessageHandler, handlers);
+            GraphClientFactory.DefaultHttpHandler = () => httpMessageHandler;
+            this.httpClient = GraphClientFactory.Create("v1.0", GraphClientFactory.Global_Cloud, handlers);
+        }
+
+        /// <summary>
+        /// Gets or sets the cache control header for requests;
+        /// </summary>
+        public CacheControlHeaderValue CacheControlHeader
+        {
+            get
+            {
+                return this.httpClient.DefaultRequestHeaders.CacheControl;
+            }
+
+            set
+            {
+                this.httpClient.DefaultRequestHeaders.CacheControl = value;
+            }
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
@@ -10,11 +10,6 @@ namespace Microsoft.Graph
     public interface IBaseClient
     {
         /// <summary>
-        /// Gets the <see cref="IAuthenticationProvider"/> for authenticating HTTP requests.
-        /// </summary>
-        IAuthenticationProvider AuthenticationProvider { get; }
-
-        /// <summary>
         /// Gets the base URL for requests of the client.
         /// </summary>
         string BaseUrl { get; }

--- a/src/Microsoft.Graph.Core/Requests/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/RedirectHandler.cs
@@ -51,6 +51,15 @@ namespace Microsoft.Graph
             // check response status code 
             if (IsRedirect(response.StatusCode))
             {
+                if (response.Headers.Location == null)
+                {
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = ErrorConstants.Codes.GeneralException,
+                            Message = ErrorConstants.Messages.LocationHeaderNotSetOnRedirect,
+                        });
+                }
 
                 var redirectCount = 0;
 

--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -13,7 +13,7 @@
     <PackageId>Microsoft.Graph</PackageId>
     <PackageTags>Microsoft Office365;Graph;GraphServiceClient;Outlook;OneDrive;AzureAD;GraphAPI;Productivity;SharePoint;Intune;SDK</PackageTags>
     <PackageReleaseNotes>
-December 2018 Release Summary (version 1.13.0)
+January 2019 Release Summary (version 1.13.0-preview.2)
 
 New functionality
 - Added new Teams API functionality.
@@ -25,6 +25,7 @@ Updated functionality
 - Device is updated with the MemberOf relationship.
 - Group is updated with the isArchived property and Team relationship.
 - User is updated with the JoinedTeams relationship.
+- Removed Newtonsoft.Json package reference upper bound limitation.
     </PackageReleaseNotes>
     <PackageProjectUrl>https://developer.microsoft.com/graph</PackageProjectUrl>
     <PackageLicenseUrl>http://aka.ms/devservicesagreement</PackageLicenseUrl>
@@ -44,7 +45,7 @@ Updated functionality
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>1.13.0-preview</Version>
+    <Version>1.13.0-preview.2</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.1|AnyCPU'">
     <DocumentationFile>bin\Release\Microsoft.Graph.xml</DocumentationFile>
@@ -57,7 +58,7 @@ Updated functionality
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Newtonsoft.Json" Version="[6.0.1,12)" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/src/Microsoft.Graph/Requests/Extensions/TeamRequestExtensions.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/TeamRequestExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+
+namespace Microsoft.Graph
+{
+    public partial interface ITeamRequest
+    {
+        /// <summary>
+        /// Creates the specified Team using PUT.
+        /// </summary>
+        /// <param name="teamToCreate">The Team to create.</param>
+        /// <returns>The created Team.</returns>
+        System.Threading.Tasks.Task<Team> PutAsync(Team teamToCreate);        
+        
+        /// <summary>
+        /// Creates the specified Team using PUT.
+        /// </summary>
+        /// <param name="teamToCreate">The Team to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created Team.</returns>
+        System.Threading.Tasks.Task<Team> PutAsync(Team teamToCreate, CancellationToken cancellationToken);
+    }
+
+    public partial class TeamRequest
+    {
+        /// <summary>
+        /// Creates the specified Team using PUT.
+        /// </summary>
+        /// <param name="teamToCreate">The Team to create.</param>
+        /// <returns>The created Team.</returns>
+        public System.Threading.Tasks.Task<Team> PutAsync(Team teamToCreate)
+        {
+            return this.PutAsync(teamToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified Team using PUT.
+        /// </summary>
+        /// <param name="teamToCreate">The Team to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created Team.</returns>
+        public async System.Threading.Tasks.Task<Team> PutAsync(Team teamToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PUT";
+            var newEntity = await this.SendAsync<Team>(teamToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+    }
+}

--- a/src/Microsoft.Graph/Requests/UploadChunkRequest.cs
+++ b/src/Microsoft.Graph/Requests/UploadChunkRequest.cs
@@ -153,11 +153,6 @@ namespace Microsoft.Graph
                 throw new ArgumentNullException(nameof(this.RequestUrl), "Session Upload URL cannot be null or empty.");
             }
 
-            if (this.Client.AuthenticationProvider == null)
-            {
-                throw new ArgumentNullException(nameof(this.Client.AuthenticationProvider), "Client.AuthenticationProvider must not be null.");
-            }
-
             using (var request = this.GetHttpRequestMessage())
             {
                 request.Content = new StreamContent(stream);

--- a/tests/Microsoft.Graph.Core.Test/Mocks/MockAuthenticationProvider.cs
+++ b/tests/Microsoft.Graph.Core.Test/Mocks/MockAuthenticationProvider.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Graph.Core.Test.Mocks
 {
     using System.Net.Http;
+    using System.Net.Http.Headers;
     using System.Threading.Tasks;
 
     using Moq;
@@ -18,6 +19,7 @@ namespace Microsoft.Graph.Core.Test.Mocks
 
             this.Setup(
                 provider => provider.AuthenticateRequestAsync(It.IsAny<HttpRequestMessage>()))
+                .Callback<HttpRequestMessage>(r => r.Headers.Authorization = new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, "Token"))
                 .Returns(Task.FromResult(0));
         }
     }

--- a/tests/Microsoft.Graph.Core.Test/Requests/AsyncMonitorTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/AsyncMonitorTests.cs
@@ -43,7 +43,6 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             this.client = new Mock<IBaseClient>(MockBehavior.Strict);
             this.client.SetupAllProperties();
-            this.client.SetupGet(client => client.AuthenticationProvider).Returns(this.authenticationProvider.Object);
             this.client.SetupGet(client => client.HttpProvider).Returns(this.httpProvider.Object);
 
             this.progress = new MockProgress();
@@ -94,16 +93,6 @@ namespace Microsoft.Graph.Core.Test.Requests
                 Assert.IsTrue(called, "Progress not called");
                 Assert.IsNotNull(item, "No item returned.");
                 Assert.AreEqual("id", item.Id, "Unexpected item returned.");
-                
-                this.authenticationProvider.Verify(
-                    provider => provider.AuthenticateRequestAsync(
-                        It.Is<HttpRequestMessage>(message => message.RequestUri.ToString().Equals(AsyncMonitorTests.monitorUrl))),
-                    Times.Once);
-
-                this.authenticationProvider.Verify(
-                    provider => provider.AuthenticateRequestAsync(
-                        It.Is<HttpRequestMessage>(message => message.RequestUri.ToString().Equals(AsyncMonitorTests.itemUrl))),
-                    Times.Once);
             }
         }
 

--- a/tests/Microsoft.Graph.Core.Test/Requests/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/AuthenticationHandlerTests.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Graph.Core.Test.Requests
         }
 
         [TestMethod]
-        public void AuthHandler_DefaultConstructor()
+        public void AuthHandler_AuthProviderConstructor()
         {
-            using (AuthenticationHandler auth = new AuthenticationHandler())
+            using (AuthenticationHandler auth = new AuthenticationHandler(mockAuthenticationProvider.Object))
             {
                 Assert.IsNull(auth.InnerHandler, "Http message handler initialized");
-                Assert.IsNull(auth.AuthenticationProvider, "Authentication provider initialized");
+                Assert.IsNotNull(auth.AuthenticationProvider, "Authentication provider initialized");
                 Assert.IsInstanceOfType(auth, typeof(AuthenticationHandler), "Unexpected authentication handler set");
             }
         }

--- a/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -21,7 +21,6 @@ namespace Microsoft.Graph.Core.Test.Requests
     {
         private DelegatingHandler[] handlers = new DelegatingHandler[3];
         private MockRedirectHandler testHttpMessageHandler;
-        private MockAuthenticationProvider authenticationProvider = new MockAuthenticationProvider();
 
 
         [TestInitialize]
@@ -30,7 +29,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             this.testHttpMessageHandler = new MockRedirectHandler();
             handlers[0] = new RetryHandler();
             handlers[1] = new RedirectHandler();
-            handlers[2] = new AuthenticationHandler(authenticationProvider.Object);
+            handlers[2] = new AuthenticationHandler();
         }
 
         [TestCleanup]
@@ -42,7 +41,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreatePipelineWithoutHttpMessageHandlerInput()
         {
-            using (RetryHandler retryHandler = (RetryHandler)GraphClientFactory.CreatePipeline(null, handlers))
+            using (RetryHandler retryHandler = (RetryHandler)GraphClientFactory.CreatePipeline(handlers))
             using (RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler)
             using (AuthenticationHandler authenticationHandler = (AuthenticationHandler) redirectHandler.InnerHandler)
             using (HttpMessageHandler innerMost = authenticationHandler.InnerHandler)
@@ -62,7 +61,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreatePipelineWithHttpMessageHandlerInput()
         {
-            using (RetryHandler retryHandler = (RetryHandler)GraphClientFactory.CreatePipeline(this.testHttpMessageHandler, handlers))
+            using (RetryHandler retryHandler = (RetryHandler)GraphClientFactory.CreatePipeline(handlers,this.testHttpMessageHandler))
             using (RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler)
             using (AuthenticationHandler authenticationHandler = (AuthenticationHandler)redirectHandler.InnerHandler)
             using (MockRedirectHandler innerMost = (MockRedirectHandler)authenticationHandler.InnerHandler)
@@ -82,10 +81,11 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreatePipelineWithoutPipeline()
         {
-            using (MockRedirectHandler handler = (MockRedirectHandler)GraphClientFactory.CreatePipeline(this.testHttpMessageHandler, null))
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
+            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(handlers: handlers))
             {
                 Assert.IsNotNull(handler, "Create a middleware pipeline failed.");
-                Assert.IsInstanceOfType(handler, typeof(MockRedirectHandler), "Inner most HttpMessageHandler class error.");
+                Assert.IsInstanceOfType(handler, typeof(RetryHandler), "Inner most HttpMessageHandler class error.");
             }
         }
 
@@ -95,14 +95,14 @@ namespace Microsoft.Graph.Core.Test.Requests
             var timeout = TimeSpan.FromSeconds(200);
             var baseAddress = new Uri("https://localhost");
             var cacheHeader = new CacheControlHeaderValue();
-            var webProxy = new WebProxy("http://127.0.0.1:8888");
-            using (HttpClient client = GraphClientFactory.CreateClient(webProxy, handlers))
+            GraphClientFactory.Proxy = new WebProxy("http://127.0.0.1:8888");
+
+            using (HttpClient client = GraphClientFactory.Create())
             {
-                GraphClientFactory.Configure(client, timeout, baseAddress, cacheHeader);
+                client.Timeout = timeout;
+                client.BaseAddress = baseAddress;
                 Assert.IsNotNull(client, "Create Http client failed.");
                 Assert.AreEqual(client.Timeout, timeout, "Unexpected default timeout set.");
-                Assert.IsFalse(client.DefaultRequestHeaders.CacheControl.NoCache, "NoCache true.");
-                Assert.IsFalse(client.DefaultRequestHeaders.CacheControl.NoStore, "NoStore true.");
                 Assert.AreEqual(client.BaseAddress, baseAddress, "Unexpected default baseAddress set.");
             }
         }
@@ -110,8 +110,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreateClient_SelectedCloudAndVersion()
         {
-            GraphClientFactory.Version = "beta";
-            using (HttpClient httpClient = GraphClientFactory.CreateClient(GraphClientFactory.Germany_Cloud, handlers))
+            using (HttpClient httpClient = GraphClientFactory.Create(version: "beta", nationalCloud: GraphClientFactory.Germany_Cloud))
             {
                 Assert.IsNotNull(httpClient, "Create Http client failed.");
                 Uri clouldEndpoint = new Uri("https://graph.microsoft.de/beta");
@@ -126,7 +125,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             string nation = "Canada";
             try
             {
-                HttpClient httpClient = GraphClientFactory.CreateClient(nation, handlers);
+                HttpClient httpClient = GraphClientFactory.Create(nationalCloud: nation);
             }
             catch (ArgumentException exception)
             {
@@ -138,8 +137,8 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreateClient_WithInnerHandler()
         {
-
-            using (HttpClient httpClient = GraphClientFactory.CreateClient(this.testHttpMessageHandler, null))
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
+            using (HttpClient httpClient = GraphClientFactory.Create())
             {
                 Assert.IsNotNull(httpClient, "Create Http client failed.");
                 Assert.IsTrue(httpClient.DefaultRequestHeaders.Contains(CoreConstants.Headers.SdkVersionHeaderName), "SDK version not set.");
@@ -161,7 +160,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreateClient_WithHandlers()
         {
-            using (HttpClient client = GraphClientFactory.CreateClient(handlers))
+            using (HttpClient client = GraphClientFactory.Create())
             {
                 Assert.IsNotNull(client, "Create Http client failed.");
             }
@@ -177,8 +176,9 @@ namespace Microsoft.Graph.Core.Test.Requests
             redirectResponse.Headers.Location = new Uri("http://example.org/bar");
             var oKResponse = new HttpResponseMessage(HttpStatusCode.OK);
             this.testHttpMessageHandler.SetHttpResponse(redirectResponse, oKResponse);
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
 
-            using (HttpClient client = GraphClientFactory.CreateClient(this.testHttpMessageHandler, handlers))
+            using (HttpClient client = GraphClientFactory.Create())
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreEqual(response, oKResponse, "Middleware pipeline not work.");
@@ -199,8 +199,9 @@ namespace Microsoft.Graph.Core.Test.Requests
             var response_2 = new HttpResponseMessage(HttpStatusCode.OK);
 
             this.testHttpMessageHandler.SetHttpResponse(retryResponse, response_2);
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
 
-            using (HttpClient client = GraphClientFactory.CreateClient(this.testHttpMessageHandler, handlers))
+            using (HttpClient client = GraphClientFactory.Create())
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, response_2);
@@ -212,7 +213,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         }
 
         [TestMethod]
-        public async Task SendRequest_UnauthorizedWithNullAuthenticationProvider()
+        public async Task SendRequest_UnauthorizedWithNoAuthenticationProvider()
         {
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, "https://example.com/bar");
             httpRequestMessage.Content = new StringContent("Hello World");
@@ -221,20 +222,13 @@ namespace Microsoft.Graph.Core.Test.Requests
             var okResponse = new HttpResponseMessage(HttpStatusCode.OK);
 
             testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, okResponse);
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
 
-            handlers[2] = new AuthenticationHandler(null);
-
-            using (HttpClient client = GraphClientFactory.CreateClient(testHttpMessageHandler, handlers))
+            using (HttpClient client = GraphClientFactory.Create())
             {
-                try
-                {
-                    var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
-                }
-                catch (ServiceException exception)
-                {
-                    Assert.AreSame(exception.Error.Message, ErrorConstants.Messages.AuthenticationProviderMissing);
-                    Assert.IsTrue(exception.IsMatch(ErrorConstants.Codes.InvalidRequest));
-                }
+                var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
+                Assert.AreSame(response, unauthorizedResponse);
+                Assert.AreSame(response.RequestMessage, httpRequestMessage);
             }
         }
 
@@ -249,7 +243,11 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, okResponse);
 
-            using (HttpClient client = GraphClientFactory.CreateClient(testHttpMessageHandler, handlers))
+            handlers[2] = new AuthenticationHandler(new MockAuthenticationProvider().Object);
+
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
+
+            using (HttpClient client = GraphClientFactory.Create( handlers: handlers))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, okResponse);
@@ -263,7 +261,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             handlers[handlers.Length - 1] = null;
             try
             {
-                HttpClient client = GraphClientFactory.CreateClient(handlers);
+                HttpClient client = GraphClientFactory.Create(handlers: handlers);
             }
             catch (ArgumentNullException exception)
             {
@@ -273,7 +271,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             handlers[handlers.Length - 1] = new RetryHandler(this.testHttpMessageHandler);
             try
             {
-                HttpClient client = GraphClientFactory.CreateClient(handlers);
+                HttpClient client = GraphClientFactory.Create(handlers: handlers);
             }
             catch (ArgumentException exception)
             {

--- a/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph.Core.Test.Requests
     {
         private DelegatingHandler[] handlers = new DelegatingHandler[3];
         private MockRedirectHandler testHttpMessageHandler;
-
+        private MockAuthenticationProvider authenticationProvider = new MockAuthenticationProvider();
 
         [TestInitialize]
         public void Setup()
@@ -29,7 +29,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             this.testHttpMessageHandler = new MockRedirectHandler();
             handlers[0] = new RetryHandler();
             handlers[1] = new RedirectHandler();
-            handlers[2] = new AuthenticationHandler();
+            handlers[2] = new AuthenticationHandler(authenticationProvider.Object);
         }
 
         [TestCleanup]

--- a/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
@@ -43,9 +43,8 @@ namespace Microsoft.Graph.Core.Test.Requests
         {
             var timeout = TimeSpan.FromSeconds(200);
             var cacheHeader = new CacheControlHeaderValue();
-            using (var defaultHttpProvider = new HttpProvider(authProvider.Object, null))
+            using (var defaultHttpProvider = new HttpProvider(null) { CacheControlHeader = cacheHeader, OverallTimeout = timeout })
             {
-                GraphClientFactory.Configure(defaultHttpProvider.httpClient, timeout, null, cacheHeader);
                 Assert.IsFalse(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoCache, "NoCache true.");
                 Assert.IsFalse(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoStore, "NoStore true.");
 
@@ -111,7 +110,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             try
             {
-                GraphClientFactory.Configure(this.httpProvider.httpClient, new TimeSpan(0, 0, 30), null, null);
+                this.httpProvider.OverallTimeout = new TimeSpan(0, 0, 30);
             }
             catch (ServiceException serviceException)
             {

--- a/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
@@ -23,12 +23,13 @@ namespace Microsoft.Graph.Core.Test.Requests
         private HttpProvider httpProvider;
         private MockSerializer serializer = new MockSerializer();
         private TestHttpMessageHandler testHttpMessageHandler;
+        private MockAuthenticationProvider authProvider = new MockAuthenticationProvider();
 
         [TestInitialize]
         public void Setup()
         {
             this.testHttpMessageHandler = new TestHttpMessageHandler();
-            this.httpProvider = new HttpProvider(this.testHttpMessageHandler, true, this.serializer.Object);
+            this.httpProvider = new HttpProvider(authProvider.Object, this.testHttpMessageHandler, true, this.serializer.Object);
         }
 
         [TestCleanup]
@@ -42,8 +43,9 @@ namespace Microsoft.Graph.Core.Test.Requests
         {
             var timeout = TimeSpan.FromSeconds(200);
             var cacheHeader = new CacheControlHeaderValue();
-            using (var defaultHttpProvider = new HttpProvider(null) { CacheControlHeader = cacheHeader, OverallTimeout = timeout })
+            using (var defaultHttpProvider = new HttpProvider(authProvider.Object, null))
             {
+                GraphClientFactory.Configure(defaultHttpProvider.httpClient, timeout, null, cacheHeader);
                 Assert.IsFalse(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoCache, "NoCache true.");
                 Assert.IsFalse(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoStore, "NoStore true.");
 
@@ -57,7 +59,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         public void HttpProvider_CustomHttpClientHandler()
         {
             using (var httpClientHandler = new HttpClientHandler())
-            using (var httpProvider = new HttpProvider(httpClientHandler, false, null))
+            using (var httpProvider = new HttpProvider(authProvider.Object, httpClientHandler, false, null))
             {
                 Assert.AreEqual(httpClientHandler, httpProvider.httpMessageHandler, "Unexpected message handler set.");
                 Assert.IsFalse(httpProvider.disposeHandler, "Dispose handler set to true.");
@@ -67,7 +69,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void HttpProvider_DefaultConstructor()
         {
-            using (var defaultHttpProvider = new HttpProvider())
+            using (var defaultHttpProvider = new HttpProvider(authProvider.Object))
             {
                 Assert.IsTrue(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoCache, "NoCache false.");
                 Assert.IsTrue(defaultHttpProvider.httpClient.DefaultRequestHeaders.CacheControl.NoStore, "NoStore false.");
@@ -86,7 +88,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         public void HttpProvider_HttpMessageHandlerConstructor()
         {
            
-            using (var httpProvider = new HttpProvider(this.testHttpMessageHandler, true, null))
+            using (var httpProvider = new HttpProvider(authProvider.Object, this.testHttpMessageHandler, true, null))
             {
                 Assert.IsNotNull(httpProvider.httpMessageHandler, "HttpMessageHandler not initialized");
                 Assert.AreEqual(httpProvider.httpMessageHandler, this.testHttpMessageHandler, "Unexpected message handler set.");
@@ -109,7 +111,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             try
             {
-                this.httpProvider.OverallTimeout = new TimeSpan(0, 0, 30);
+                GraphClientFactory.Configure(this.httpProvider.httpClient, new TimeSpan(0, 0, 30), null, null);
             }
             catch (ServiceException serviceException)
             {
@@ -146,7 +148,7 @@ namespace Microsoft.Graph.Core.Test.Requests
                 this.httpProvider.Dispose();
 
                 var clientException = new Exception();
-                this.httpProvider = new HttpProvider(new ExceptionHttpMessageHandler(clientException), /* disposeHandler */ true, null);
+                this.httpProvider = new HttpProvider(authProvider.Object, new ExceptionHttpMessageHandler(clientException), /* disposeHandler */ true, null);
 
                 try
                 {
@@ -172,7 +174,7 @@ namespace Microsoft.Graph.Core.Test.Requests
                 this.httpProvider.Dispose();
 
                 var clientException = new TaskCanceledException();
-                this.httpProvider = new HttpProvider(new ExceptionHttpMessageHandler(clientException), /* disposeHandler */ true, null);
+                this.httpProvider = new HttpProvider(authProvider.Object, new ExceptionHttpMessageHandler(clientException), /* disposeHandler */ true, null);
 
                 try
                 {
@@ -182,7 +184,7 @@ namespace Microsoft.Graph.Core.Test.Requests
                 {
                     Assert.IsTrue(exception.IsMatch(ErrorConstants.Codes.Timeout), "Unexpected error code returned.");
                     Assert.AreEqual(ErrorConstants.Messages.RequestTimedOut, exception.Error.Message, "Unexpected error message.");
-                    Assert.AreEqual(clientException, exception.InnerException, "Inner exception not set.");
+                    Assert.AreEqual(clientException.Message, exception.InnerException.Message, "Inner exception not set.");
 
                     throw;
                 }
@@ -225,9 +227,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             using (var redirectResponseMessage = new HttpResponseMessage())
             using (var finalResponseMessage = new HttpResponseMessage())
             {
-                httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue("bearer", "token");
                 httpRequestMessage.Headers.Add("testHeader", "testValue");
-                httpRequestMessage.Headers.CacheControl = new CacheControlHeaderValue { NoCache = true, NoStore = true };
 
                 redirectResponseMessage.StatusCode = HttpStatusCode.Redirect;
                 redirectResponseMessage.Headers.Location = new Uri("https://localhost/redirect");
@@ -238,7 +238,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
                 var returnedResponseMessage = await this.httpProvider.SendAsync(httpRequestMessage);
 
-                Assert.AreEqual(3, finalResponseMessage.RequestMessage.Headers.Count(), "Unexpected number of headers on redirect request message.");
+                Assert.AreEqual(4, finalResponseMessage.RequestMessage.Headers.Count(), "Unexpected number of headers on redirect request message.");
                 
                 foreach (var header in httpRequestMessage.Headers)
                 {
@@ -265,21 +265,19 @@ namespace Microsoft.Graph.Core.Test.Requests
                 redirectResponseMessage.StatusCode = HttpStatusCode.Redirect;
                 redirectResponseMessage.Headers.Location = new Uri("https://localhost/redirect");
                 tooManyRedirectsResponseMessage.StatusCode = HttpStatusCode.Redirect;
+                tooManyRedirectsResponseMessage.Headers.Location = new Uri("https://localhost");
 
                 redirectResponseMessage.RequestMessage = httpRequestMessage;
 
                 this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), redirectResponseMessage);
                 this.testHttpMessageHandler.AddResponseMapping(redirectResponseMessage.Headers.Location.ToString(), tooManyRedirectsResponseMessage);
 
-                httpRequestMessage.Headers.Authorization = new AuthenticationHeaderValue(CoreConstants.Headers.Bearer, "ticket");
-
                 try
                 {
-                    await this.httpProvider.HandleRedirect(
-                        redirectResponseMessage,
+                    await this.httpProvider.SendAsync(
+                        httpRequestMessage,
                         HttpCompletionOption.ResponseContentRead,
-                        CancellationToken.None,
-                        5);
+                        CancellationToken.None);
                 }
                 catch (ServiceException exception)
                 {

--- a/tests/Microsoft.Graph.Core.Test/Requests/RequestTestBase.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/RequestTestBase.cs
@@ -13,21 +13,23 @@ namespace Microsoft.Graph.Core.Test.Requests
     public class RequestTestBase
     {
         protected string baseUrl = "https://localhost/v1.0";
-
-        protected MockAuthenticationProvider authenticationProvider;
-        protected MockHttpProvider httpProvider;
+        protected HttpProvider xhttpProvider;
         protected HttpResponseMessage httpResponseMessage;
         protected IBaseClient baseClient;
         protected MockSerializer serializer;
+        protected TestHttpMessageHandler testHttpMessageHandler;
+        protected MockHttpProvider httpProvider;
+        protected MockAuthenticationProvider authenticationProvider = new MockAuthenticationProvider();
 
         [TestInitialize]
         public void Setup()
         {
-            this.authenticationProvider = new MockAuthenticationProvider();
             this.serializer = new MockSerializer();
             this.httpResponseMessage = new HttpResponseMessage();
+            this.testHttpMessageHandler = new TestHttpMessageHandler();
+            //this.httpProvider = new HttpProvider(authenticationProvider.Object, this.testHttpMessageHandler, true, this.serializer.Object);
             this.httpProvider = new MockHttpProvider(this.httpResponseMessage, this.serializer.Object);
-            
+
             this.baseClient = new BaseClient(
                 this.baseUrl,
                 this.authenticationProvider.Object,

--- a/tests/Microsoft.Graph.Core.Test/TestModels/CustomRequest.cs
+++ b/tests/Microsoft.Graph.Core.Test/TestModels/CustomRequest.cs
@@ -8,14 +8,9 @@ namespace Microsoft.Graph.Core.Test.TestModels
 
     public class CustomRequest : BaseRequest
     {
-        internal static readonly string SdkHeaderName = "Name";
-        internal static readonly string SdkHeaderValue = "Value";
-
         public CustomRequest(string baseUrl, IBaseClient baseClient, IEnumerable<Option> options = null)
             : base(baseUrl, baseClient, options)
         {
-            this.sdkVersionHeaderName = CustomRequest.SdkHeaderName;
-            this.sdkVersionHeaderValue = CustomRequest.SdkHeaderValue;
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AsyncMonitorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AsyncMonitorTests.cs
@@ -42,7 +42,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             this.client = new Mock<IBaseClient>(MockBehavior.Strict);
             this.client.SetupAllProperties();
-            this.client.SetupGet(client => client.AuthenticationProvider).Returns(this.authenticationProvider.Object);
             this.client.SetupGet(client => client.HttpProvider).Returns(this.httpProvider.Object);
 
             this.progress = new MockProgress();
@@ -92,16 +91,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 Assert.True(called);
                 Assert.NotNull(item);
                 Assert.Equal("id", item.Id);
-
-                this.authenticationProvider.Verify(
-                    provider => provider.AuthenticateRequestAsync(
-                        It.Is<HttpRequestMessage>(message => message.RequestUri.ToString().Equals(AsyncMonitorTests.monitorUrl))),
-                    Times.Once);
-
-                this.authenticationProvider.Verify(
-                    provider => provider.AuthenticateRequestAsync(
-                        It.Is<HttpRequestMessage>(message => message.RequestUri.ToString().Equals(AsyncMonitorTests.itemUrl))),
-                    Times.Once);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AuthenticationHandlerTests.cs
@@ -33,12 +33,12 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
-        public void AuthHandler_DefaultConstructor()
+        public void AuthHandler_AuthProviderConstructor()
         {
-            using (AuthenticationHandler auth = new AuthenticationHandler())
+            using (AuthenticationHandler auth = new AuthenticationHandler(mockAuthenticationProvider.Object))
             {
                 Assert.Null(auth.InnerHandler);
-                Assert.Null(auth.AuthenticationProvider);
+                Assert.NotNull(auth.AuthenticationProvider);
                 Assert.IsType(typeof(AuthenticationHandler), auth);
             }
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -77,11 +77,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 httpRequestMessage.RequestUri.GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Port, UriFormat.Unescaped));
             Assert.Equal("value1", httpRequestMessage.Headers.GetValues("header1").First());
             Assert.Equal("value2", httpRequestMessage.Headers.GetValues("header2").First());
-
-            var expectedVersion = typeof(BaseRequest).GetTypeInfo().Assembly.GetName().Version;
-            Assert.Equal(
-                string.Format("Graph-dotnet-{0}.{1}.{2}", expectedVersion.Major, expectedVersion.Minor, expectedVersion.Build),
-                httpRequestMessage.Headers.GetValues(CoreConstants.Headers.SdkVersionHeaderName).First());
         }
 
         [Fact]
@@ -95,29 +90,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             Assert.Equal(HttpMethod.Delete, httpRequestMessage.Method);
             Assert.Equal(requestUrl,
                 httpRequestMessage.RequestUri.GetComponents(UriComponents.AbsoluteUri & ~UriComponents.Port, UriFormat.Unescaped));
-            Assert.Equal(1, httpRequestMessage.Headers.Count());
-
-            var expectedVersion = typeof(BaseRequest).GetTypeInfo().Assembly.GetName().Version;
-            Assert.Equal(
-                string.Format("Graph-dotnet-{0}.{1}.{2}", expectedVersion.Major, expectedVersion.Minor, expectedVersion.Build),
-                httpRequestMessage.Headers.GetValues(CoreConstants.Headers.SdkVersionHeaderName).First());
-        }
-
-        [Fact]
-        public void GetWebRequest_OverrideCustomTelemetryHeader()
-        {
-            var requestUrl = string.Concat(this.baseUrl, "/me/drive/items/id");
-
-            var baseRequest = new CustomRequest(requestUrl, this.baseClient);
-
-            var httpRequestMessage = baseRequest.GetHttpRequestMessage();
-
-            Assert.Equal(
-                CustomRequest.SdkHeaderValue,
-                httpRequestMessage.Headers.GetValues(CustomRequest.SdkHeaderName).First());
-
-            Assert.False(
-                httpRequestMessage.Headers.Contains(CoreConstants.Headers.SdkVersionHeaderName));
+            Assert.Equal(0, httpRequestMessage.Headers.Count());
         }
 
         [Fact]
@@ -155,8 +128,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
                 Assert.NotNull(responseItem);
                 Assert.Equal(expectedResponseItem.Id, responseItem.Id);
-
-                this.authenticationProvider.Verify(provider => provider.AuthenticateRequestAsync(It.IsAny<HttpRequestMessage>()), Times.Once);
             }
         }
 
@@ -207,8 +178,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                     .Returns(string.Empty);
 
                 await baseRequest.SendAsync("string", CancellationToken.None);
-
-                this.authenticationProvider.Verify(provider => provider.AuthenticateRequestAsync(It.IsAny<HttpRequestMessage>()), Times.Once);
             }
         }
 
@@ -239,8 +208,6 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 var instance = await baseRequest.SendAsync<DerivedTypeClass>("string", CancellationToken.None);
 
                 Assert.Null(instance);
-
-                this.authenticationProvider.Verify(provider => provider.AuthenticateRequestAsync(It.IsAny<HttpRequestMessage>()), Times.Once);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -18,17 +18,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
     public class GraphClientFactoryTests : IDisposable
     {
-        private DelegatingHandler[] handlers = new DelegatingHandler[3];
         private MockRedirectHandler testHttpMessageHandler;
-        private MockAuthenticationProvider mockAuthenticationProvider = new MockAuthenticationProvider();
-
 
         public GraphClientFactoryTests()
         {
             this.testHttpMessageHandler = new MockRedirectHandler();
-            handlers[0] = new RetryHandler();
-            handlers[1] = new RedirectHandler();
-            handlers[2] = new AuthenticationHandler(mockAuthenticationProvider.Object);
         }
 
         public void Dispose()
@@ -39,7 +33,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreatePipelineWithoutHttpMessageHandlerInput()
         {
-            using (RetryHandler retryHandler = (RetryHandler)GraphClientFactory.CreatePipeline(null, handlers))
+            using (RetryHandler retryHandler = (RetryHandler)GraphClientFactory.CreateDefaultHandlers())
             using (RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler)
             using (AuthenticationHandler authenticationHandler = (AuthenticationHandler)redirectHandler.InnerHandler)
             using (HttpClientHandler innerMost = (HttpClientHandler)authenticationHandler.InnerHandler)
@@ -59,7 +53,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreatePipelineWithHttpMessageHandlerInput()
         {
-            using (RetryHandler retryHandler = (RetryHandler)GraphClientFactory.CreatePipeline(this.testHttpMessageHandler, handlers))
+            using (RetryHandler retryHandler = (RetryHandler)GraphClientFactory.CreatePipeline(null, this.testHttpMessageHandler))
             using (RedirectHandler redirectHandler = (RedirectHandler)retryHandler.InnerHandler)
             using (AuthenticationHandler authenticationHandler = (AuthenticationHandler)redirectHandler.InnerHandler)
             using (MockRedirectHandler innerMost = (MockRedirectHandler)authenticationHandler.InnerHandler)
@@ -78,7 +72,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreatePipelineWithoutPipeline()
         {
-            using (MockRedirectHandler handler = (MockRedirectHandler)GraphClientFactory.CreatePipeline(this.testHttpMessageHandler, null))
+            using (MockRedirectHandler handler = (MockRedirectHandler)GraphClientFactory.CreatePipeline(null, this.testHttpMessageHandler))
             {
                 Assert.NotNull(handler);
                 Assert.IsType(typeof(MockRedirectHandler), handler);
@@ -92,23 +86,20 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var baseAddress = new Uri("https://localhost");
             var cacheHeader = new CacheControlHeaderValue();
             
-            using (HttpClient client = GraphClientFactory.CreateClient(handlers))
+            using (HttpClient client = GraphClientFactory.Create())
             {
-                GraphClientFactory.Configure(client, timeout, baseAddress, cacheHeader);
+                client.Timeout = timeout;
+                client.BaseAddress = baseAddress;
                 Assert.NotNull(client);
                 Assert.Equal(client.Timeout, timeout);
-                Assert.False(client.DefaultRequestHeaders.CacheControl.NoCache, "NoCache true.");
-                Assert.False(client.DefaultRequestHeaders.CacheControl.NoStore, "NoStore true.");
                 Assert.Equal(client.BaseAddress, baseAddress);
-
             }
         }
 
         [Fact]
         public void CreateClient_SelectedCloud()
         {
-            GraphClientFactory.Version = "beta";
-            using (HttpClient httpClient = GraphClientFactory.CreateClient(GraphClientFactory.Germany_Cloud, handlers))
+            using (HttpClient httpClient = GraphClientFactory.Create(version: "beta", nationalCloud: GraphClientFactory.Germany_Cloud))
             {
                 Assert.NotNull(httpClient);
                 Uri clouldEndpoint = new Uri("https://graph.microsoft.de/beta");
@@ -123,7 +114,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             string nation = "Canada";
             try
             {
-                HttpClient httpClient = GraphClientFactory.CreateClient(nation, handlers);
+                HttpClient httpClient = GraphClientFactory.Create(nationalCloud: nation);
             }
             catch (ArgumentException exception)
             {
@@ -135,8 +126,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreateClient_WithInnerHandler()
         {
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
 
-            using (HttpClient httpClient = GraphClientFactory.CreateClient(this.testHttpMessageHandler, null))
+            using (HttpClient httpClient = GraphClientFactory.Create())
             {
                 Assert.NotNull(httpClient);
                 Assert.True(httpClient.DefaultRequestHeaders.Contains(CoreConstants.Headers.SdkVersionHeaderName), "SDK version not set.");
@@ -157,7 +149,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreateClient_WithHandlers()
         {
-            using (HttpClient client = GraphClientFactory.CreateClient(handlers))
+            using (HttpClient client = GraphClientFactory.Create(handlers: GraphClientFactory.CreateDefaultHandlers()))
             {
                 Assert.NotNull(client);
 
@@ -174,8 +166,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             redirectResponse.Headers.Location = new Uri("http://example.org/bar");
             var oKResponse = new HttpResponseMessage(HttpStatusCode.OK);
             this.testHttpMessageHandler.SetHttpResponse(redirectResponse, oKResponse);
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
 
-            using (HttpClient client = GraphClientFactory.CreateClient(this.testHttpMessageHandler, handlers))
+            using (HttpClient client = GraphClientFactory.Create())
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.Equal(response, oKResponse);
@@ -196,8 +189,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var response_2 = new HttpResponseMessage(HttpStatusCode.OK);
 
             this.testHttpMessageHandler.SetHttpResponse(retryResponse, response_2);
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
 
-            using (HttpClient client = GraphClientFactory.CreateClient(this.testHttpMessageHandler, handlers))
+            using (HttpClient client = GraphClientFactory.Create())
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.Same(response, response_2);
@@ -210,7 +204,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
-        public async Task SendRequest_UnauthorizedWithNullAuthenticationProvider()
+        public async Task SendRequest_UnauthorizedWithNoAuthenticationProvider()
         {
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Put, "https://example.com/bar");
             httpRequestMessage.Content = new StringContent("Hello World");
@@ -220,21 +214,12 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, okResponse);
 
-            handlers[2] = new AuthenticationHandler(null);
-
-            try
+            GraphClientFactory.DefaultHttpHandler = () => testHttpMessageHandler;
+            using (HttpClient client = GraphClientFactory.Create())
             {
-                using (HttpClient client = GraphClientFactory.CreateClient(testHttpMessageHandler, handlers))
-                {
-                    var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
-                    Assert.Same(response, unauthorizedResponse);
-                    Assert.Same(response.RequestMessage, httpRequestMessage);
-                }
-            }
-            catch (Exception exception)
-            {
-                Assert.IsType(typeof(ServiceException), exception);
-                Assert.Contains(ErrorConstants.Messages.AuthenticationProviderMissing, exception.Message);
+                var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
+                Assert.Same(response, unauthorizedResponse);
+                Assert.Same(response.RequestMessage, httpRequestMessage);
             }
         }
 
@@ -249,7 +234,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, okResponse);
 
-            using (HttpClient client = GraphClientFactory.CreateClient(testHttpMessageHandler, handlers))
+            var authHandler = new AuthenticationHandler(new MockAuthenticationProvider().Object);
+            var pipeline = GraphClientFactory.CreateDefaultHandlers();
+
+            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
+            using (HttpClient client = GraphClientFactory.Create())
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.Same(response, okResponse);
@@ -260,10 +249,11 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreateClient_WithHandlersHasExceptions()
         {
+            var handlers = GraphClientFactory.CreateDefaultHandlers().ToArray();
             handlers[handlers.Length - 1] = null;
             try
             {
-                HttpClient client = GraphClientFactory.CreateClient(handlers);
+                HttpClient client = GraphClientFactory.Create(handlers: handlers);
             }
             catch (ArgumentNullException exception)
             {
@@ -274,7 +264,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             handlers[handlers.Length - 1] = new RetryHandler(this.testHttpMessageHandler);
             try
             {
-                HttpClient client = GraphClientFactory.CreateClient(handlers);
+                HttpClient client = GraphClientFactory.Create(handlers: handlers);
             }
             catch (ArgumentException exception)
             {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
     {
         private MockRedirectHandler testHttpMessageHandler;
         private DelegatingHandler[] handlers;
+        private MockAuthenticationProvider authenticationProvider = new MockAuthenticationProvider();
 
         public GraphClientFactoryTests()
         {
@@ -27,7 +28,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             handlers = handlers = new DelegatingHandler[3];
             handlers[0] = new RetryHandler();
             handlers[1] = new RedirectHandler();
-            handlers[2] = new AuthenticationHandler();
+            handlers[2] = new AuthenticationHandler(authenticationProvider.Object);
 
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/CustomRequest.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/TestModels/CustomRequest.cs
@@ -11,14 +11,9 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.TestModels
 {
     public class CustomRequest : BaseRequest
     {
-        internal static readonly string SdkHeaderName = "Name";
-        internal static readonly string SdkHeaderValue = "Value";
-
         public CustomRequest(string baseUrl, IBaseClient baseClient, IEnumerable<Option> options = null)
             : base(baseUrl, baseClient, options)
         {
-            this.sdkVersionHeaderName = CustomRequest.SdkHeaderName;
-            this.sdkVersionHeaderValue = CustomRequest.SdkHeaderValue;
         }
     }
 }

--- a/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
+++ b/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Requests\Functional\ContactTests.cs" />
     <Compile Include="Requests\Functional\EventTests.cs" />
     <Compile Include="Requests\Functional\GraphTestBase.cs" />
+    <Compile Include="Requests\Functional\GroupTests.cs" />
     <Compile Include="Requests\Functional\MailTests.cs" />
     <Compile Include="Requests\Functional\OneDriveTests.cs" />
     <Compile Include="Requests\Functional\ErrorTests.cs" />

--- a/tests/Microsoft.Graph.Test/Requests/Functional/ExcelTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/ExcelTests.cs
@@ -502,9 +502,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
 
                 HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Get, urlToGetImageFromChart);
 
-                // Authenticate (add access token) our HttpRequestMessage
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                 // Send the request and get the response.
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);
 

--- a/tests/Microsoft.Graph.Test/Requests/Functional/GroupTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/GroupTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using Async = System.Threading.Tasks;
+
+namespace Microsoft.Graph.Test.Requests.Functional
+{
+    [Ignore]
+    [TestClass]
+    public class GroupTests : GraphTestBase
+    {
+        /// <summary>
+        /// Create a team on a group.
+        /// </summary>
+        [TestMethod]
+        public async Async.Task GroupCreateTeam()
+        {
+            try
+            {
+                // Get a groups collection. We'll use the first entry to add the team. Results in a call to the service.
+                IGraphServiceGroupsCollectionPage groupPage = await graphClient.Groups.Request().GetAsync();
+
+                // Create a team with settings.
+                Team team = new Team()
+                {
+                    MemberSettings = new TeamMemberSettings()
+                    {
+                        AllowCreateUpdateChannels = true
+                    }
+                };
+
+                // Add a team to the group.  Results in a call to the service.
+                await graphClient.Groups[groupPage[8].Id].Team.Request().PutAsync(team);
+            }
+            catch (ServiceException e)
+            {
+                Assert.Fail(e.Error.ToString());
+            }
+        }
+    }
+}

--- a/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/MiscTests.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
         [Ignore]
         public async Async.Task ManualAdHocTimeoutTest()
         {
-            graphClient.HttpProvider.OverallTimeout = new TimeSpan(0, 0, 7);
+            // graphClient.HttpProvider.OverallTimeout = new TimeSpan(0, 0, 7);
             try
             {
                 User me = await graphClient.Me.Request().GetAsync();

--- a/tests/Microsoft.Graph.Test/Requests/Functional/OneNoteTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/OneNoteTests.cs
@@ -358,9 +358,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                 hrm.Content = new StringContent(htmlBody, System.Text.Encoding.UTF8, "text/html");
 
-                // Authenticate (add access token) our HttpRequestMessage
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                 // Send the request and get the response.
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);
 
@@ -426,9 +423,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     // Create the request message and add the content.
                     HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                     hrm.Content = body;
-
-                    // Authenticate (add access token to) our HttpRequestMessage
-                    await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
 
                     // Send the request and get the response.
                     response = await graphClient.HttpProvider.SendAsync(hrm);
@@ -516,9 +510,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                     HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Post, requestUrl);
                     hrm.Content = multiPartContent;
 
-                    // Authenticate (add access token to) our HttpRequestMessage
-                    await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                     // Send the request and get the response.
                     response = await graphClient.HttpProvider.SendAsync(hrm);
                 }
@@ -603,9 +594,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 string updateBodyCommandString = graphClient.HttpProvider.Serializer.SerializeObject(commands);
                 hrm.Content = new StringContent(updateBodyCommandString);
                 hrm.Content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
-
-                // Authenticate (add access token to) our request
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
 
                 // Send the request and get the response.
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);

--- a/tests/Microsoft.Graph.Test/Requests/Functional/ReportTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/ReportTests.cs
@@ -24,9 +24,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 string getOffice365ActiveUserCountsRequestUrl = graphClient.Reports.GetOffice365ActiveUserCounts("D7").Request().RequestUrl;
                 HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Get, getOffice365ActiveUserCountsRequestUrl);
 
-                // Inject the access token into the request.
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                 // Send the request and get the response. It will automatically follow the redirect to get the Report file.
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);
 

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
@@ -119,9 +119,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 string requestUrlToGetSiteRootInfo = String.Format("{0}{1}", graphClient.Sites.Request().RequestUrl, "/root");
                 HttpRequestMessage hrm = new HttpRequestMessage(HttpMethod.Get, requestUrlToGetSiteRootInfo);
 
-                // Authenticate (add access token) to our HttpRequestMessage
-                await graphClient.AuthenticationProvider.AuthenticateRequestAsync(hrm);
-
                 HttpResponseMessage response = await graphClient.HttpProvider.SendAsync(hrm);
 
                 Site site;


### PR DESCRIPTION
The GraphClientFactory is for users who want to make http calls directly with the native HttpClient but have it preconfigured for Microsoft Graph.  It is also used internally by GraphServiceClient.

## Basic usage

```csharp
var httpclient = GraphClientFactory.Create()
```

## Provide a different set of handlers

```csharp
var handlers = new [] {
  new RetryHandler()
};
var httpClient = GraphClientFactory.Create(handlers: handlers);
```

## Adjust the default set of handlers

```csharp
var handlers = GraphClientFactory.CreateDefaultHandlers().ToList();
// Update list
var httpClient = GraphClientFactory.Create(handlers: handlers);
```


## Configure a proxy

Proxies are configured once as a static property.  It is expected that a single process will use the same proxy configuration for all HttpClient instances.

```csharp
GraphClientFactory.Proxy = new WebProxy();
var httpClient = GraphClientFactory.Create();
```

## Provide a different HttpMessageHandler

It is possible to replace the function that is used for creating the HttpMessageHandler that is at the end of the middleware pipeline.  Depending on the platform there are a number of different implementations of this handler.  You can also create a mock handler for testing.  By making this a function, it is possible to either return a new handler instance or return a common instance.

```csharp
GraphClientFactory.DefaultHttpHandler = () => new WebRequestHandler();
var httpClient = GraphClientFactory.Create();
```

## Select a different NationalCloud or API version

When calling create it is possible to specify both the API version and the desired national cloud.  This will impact the default BaseAddress that will be used for making calls.  If requests are made with absolute URLs then these values will have no impact.

```csharp
var httpClient = GraphClientFactory.Create(version: "beta", nationalCloud: GraphClientFactory.Germany_Cloud);
```

