### PR TITLE
Update project Newtonsoft package reference and enable team creation on group

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -13,9 +13,10 @@
     <PackageId>Microsoft.Graph.Core</PackageId>
     <PackageTags>Microsoft Office365;Graph;GraphServiceClient;Outlook;OneDrive;AzureAD;GraphAPI;Productivity;SharePoint;Intune;SDK</PackageTags>
     <PackageReleaseNotes>
-December 2018 Release Summary (version 1.13.0)
+January 2019 Release Summary (version 1.13.0-preview.2)
 
 - Authentication handler added.
+- Removed Newtonsoft.Json package reference upper bound limitation.
     </PackageReleaseNotes>
     <PackageProjectUrl>https://developer.microsoft.com/graph</PackageProjectUrl>
     <PackageLicenseUrl>http://aka.ms/devservicesagreement</PackageLicenseUrl>
@@ -35,7 +36,7 @@ December 2018 Release Summary (version 1.13.0)
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>1.13.0-preview</Version>
+    <Version>1.13.0-preview.2</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.1|AnyCPU'">
     <DocumentationFile>bin\Release\netstandard1.1\Microsoft.Graph.Core.xml</DocumentationFile>
@@ -54,7 +55,7 @@ December 2018 Release Summary (version 1.13.0)
     <Reference Include="System.Net.Http" />
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Newtonsoft.Json" Version="[6.0.1,12)" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -13,7 +13,7 @@
     <PackageId>Microsoft.Graph</PackageId>
     <PackageTags>Microsoft Office365;Graph;GraphServiceClient;Outlook;OneDrive;AzureAD;GraphAPI;Productivity;SharePoint;Intune;SDK</PackageTags>
     <PackageReleaseNotes>
-December 2018 Release Summary (version 1.13.0)
+January 2019 Release Summary (version 1.13.0-preview.2)
 
 New functionality
 - Added new Teams API functionality.
@@ -25,6 +25,7 @@ Updated functionality
 - Device is updated with the MemberOf relationship.
 - Group is updated with the isArchived property and Team relationship.
 - User is updated with the JoinedTeams relationship.
+- Removed Newtonsoft.Json package reference upper bound limitation.
     </PackageReleaseNotes>
     <PackageProjectUrl>https://developer.microsoft.com/graph</PackageProjectUrl>
     <PackageLicenseUrl>http://aka.ms/devservicesagreement</PackageLicenseUrl>
@@ -44,7 +45,7 @@ Updated functionality
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <Version>1.13.0-preview</Version>
+    <Version>1.13.0-preview.2</Version>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.1|AnyCPU'">
     <DocumentationFile>bin\Release\Microsoft.Graph.xml</DocumentationFile>
@@ -57,7 +58,7 @@ Updated functionality
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Newtonsoft.Json" Version="[6.0.1,12)" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.1' ">
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />

--- a/src/Microsoft.Graph/Requests/Extensions/TeamRequestExtensions.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/TeamRequestExtensions.cs
@@ -1,0 +1,50 @@
+﻿using System.Threading;
+
+namespace Microsoft.Graph
+{
+    public partial interface ITeamRequest
+    {
+        /// <summary>
+        /// Creates the specified Team using PUT.
+        /// </summary>
+        /// <param name="teamToCreate">The Team to create.</param>
+        /// <returns>The created Team.</returns>
+        System.Threading.Tasks.Task<Team> PutAsync(Team teamToCreate);        
+        
+        /// <summary>
+        /// Creates the specified Team using PUT.
+        /// </summary>
+        /// <param name="teamToCreate">The Team to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created Team.</returns>
+        System.Threading.Tasks.Task<Team> PutAsync(Team teamToCreate, CancellationToken cancellationToken);
+    }
+
+    public partial class TeamRequest
+    {
+        /// <summary>
+        /// Creates the specified Team using PUT.
+        /// </summary>
+        /// <param name="teamToCreate">The Team to create.</param>
+        /// <returns>The created Team.</returns>
+        public System.Threading.Tasks.Task<Team> PutAsync(Team teamToCreate)
+        {
+            return this.PutAsync(teamToCreate, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates the specified Team using PUT.
+        /// </summary>
+        /// <param name="teamToCreate">The Team to create.</param>
+        /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
+        /// <returns>The created Team.</returns>
+        public async System.Threading.Tasks.Task<Team> PutAsync(Team teamToCreate, CancellationToken cancellationToken)
+        {
+            this.ContentType = "application/json";
+            this.Method = "PUT";
+            var newEntity = await this.SendAsync<Team>(teamToCreate, cancellationToken).ConfigureAwait(false);
+            this.InitializeCollectionProperties(newEntity);
+            return newEntity;
+        }
+    }
+}

--- a/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
+++ b/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Requests\Functional\ContactTests.cs" />
     <Compile Include="Requests\Functional\EventTests.cs" />
     <Compile Include="Requests\Functional\GraphTestBase.cs" />
+    <Compile Include="Requests\Functional\GroupTests.cs" />
     <Compile Include="Requests\Functional\MailTests.cs" />
     <Compile Include="Requests\Functional\OneDriveTests.cs" />
     <Compile Include="Requests\Functional\ErrorTests.cs" />

--- a/tests/Microsoft.Graph.Test/Requests/Functional/GroupTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/GroupTests.cs
@@ -5,7 +5,7 @@ using Async = System.Threading.Tasks;
 
 namespace Microsoft.Graph.Test.Requests.Functional
 {
-    //[Ignore]
+    [Ignore]
     [TestClass]
     public class GroupTests : GraphTestBase
     {

--- a/tests/Microsoft.Graph.Test/Requests/Functional/GroupTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/GroupTests.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
+using Async = System.Threading.Tasks;
+
+namespace Microsoft.Graph.Test.Requests.Functional
+{
+    //[Ignore]
+    [TestClass]
+    public class GroupTests : GraphTestBase
+    {
+        /// <summary>
+        /// Create a team on a group.
+        /// </summary>
+        [TestMethod]
+        public async Async.Task GroupCreateTeam()
+        {
+            try
+            {
+                // Get a groups collection. We'll use the first entry to add the team. Results in a call to the service.
+                IGraphServiceGroupsCollectionPage groupPage = await graphClient.Groups.Request().GetAsync();
+
+                // Create a team with settings.
+                Team team = new Team()
+                {
+                    MemberSettings = new TeamMemberSettings()
+                    {
+                        AllowCreateUpdateChannels = true
+                    }
+                };
+
+                // Add a team to the group.  Results in a call to the service.
+                await graphClient.Groups[groupPage[8].Id].Team.Request().PutAsync(team);
+            }
+            catch (ServiceException e)
+            {
+                Assert.Fail(e.Error.ToString());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #341 
Fixes #345

### Changes proposed in this pull request
- Remove upper bounds on the Newtonsoft.Json package reference.
- Enable creation of a team on a group. 

`await graphClient.Groups[groupPage[8].Id].Team.Request().PutAsync(team);`