### PR TITLE
Update User.cs

### DIFF
--- a/src/Microsoft.Graph/Models/Generated/User.cs
+++ b/src/Microsoft.Graph/Models/Generated/User.cs
@@ -40,7 +40,7 @@ namespace Microsoft.Graph
         /// The licenses that are assigned to the user. Not nullable.
         /// </summary>
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "assignedLicenses", Required = Newtonsoft.Json.Required.Default)]
-        public IEnumerable<AssignedLicense> AssignedLicenses { get; set; }
+        public IEnumerable<AssignedLicense> AssignedLicenses { get; }
     
         /// <summary>
         /// Gets or sets assigned plans.


### PR DESCRIPTION
AssignedLicenses property is read-only property and we get an exception "Property 'assignedLicense' is read-only and cannot be set"

<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request

AssignedLicenses is read-only property, Microsoft Graph throws an exception when this property is set,

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
-
-
-