### PR TITLE
Fixes #374: Adds route to a Site's root structural property. 

### DIFF
--- a/src/Microsoft.Graph/Requests/Extensions/GraphServiceSitesCollectionRequestBuilderExtension.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/GraphServiceSitesCollectionRequestBuilderExtension.cs
@@ -27,5 +27,16 @@ namespace Microsoft.Graph
                 string.Format("{0}/{1}:{2}", this.RequestUrl, hostname, siteRelativePath),
                 this.Client);
         }
+
+        /// <summary>
+        /// Gets a request builder for accessing a sites.
+        /// </summary>
+        public ISiteRequestBuilder Root
+        {
+            get
+            {
+                return new SiteRequestBuilder(this.AppendSegmentToRequestUrl("root"), this.Client);
+            }
+        }
     }
 }

--- a/src/Microsoft.Graph/Requests/Extensions/IGraphServiceSitesCollectionRequestBuilderExtension.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/IGraphServiceSitesCollectionRequestBuilderExtension.cs
@@ -15,5 +15,10 @@ namespace Microsoft.Graph
         /// </summary>
         /// <returns>The <see cref="ISiteRequestBuilder"/>.</returns>
         ISiteRequestBuilder GetByPath(string siteRelativePath, string hostname);
+
+        /// <summary>
+        /// Gets a request builder for accessing a site's root. This is how we can provide a request builder for structural properties.
+        /// </summary>
+        ISiteRequestBuilder Root { get; }
     }
 }

--- a/tests/Microsoft.Graph.Test/Requests/Functional/OneNoteTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/OneNoteTests.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
         private Notebook testNotebook;
         private static string firstSectionID;
 
-        [ClassInitialize]
-        public static void GetTestSectionId(TestContext c)
-        {
+        public OneNoteTests() : base() {
             // Get a page of OneNote sections.
             IOnenoteSectionsCollectionPage sectionPage = graphClient.Me
                                                                     .Onenote
@@ -31,7 +29,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
             // Get a handle to the first section.
             firstSectionID = sectionPage[0].Id;
         }
-
+        
         public async void TestPageCleanUp()
         {
             await graphClient.Me.Onenote.Pages[testPage.Id].Request().DeleteAsync();
@@ -729,6 +727,27 @@ namespace Microsoft.Graph.Test.Requests.Functional
             catch (Exception e)
             {
                 Assert.Fail("Error code: {0}", e.Message);
+            }
+        }
+
+        /// <summary>
+        /// Test the custom 'Root' partial request builder and accessing Onenote notebook collection.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Async.Task It_accesses_a_sites_OneNote_notebooks()
+        {
+            try
+            {
+                Site site = await graphClient.Sites.Root.Request().GetAsync();
+                Assert.IsNotNull(site);
+
+                IOnenoteNotebooksCollectionPage notebooks = await graphClient.Sites[site.Id].Onenote.Notebooks.Request().GetAsync();
+                Assert.IsNotNull(notebooks);
+            }
+            catch (Exception)
+            {
+                Assert.Fail("An unexpected exception was thrown. This test case failed.");
             }
         }
     }

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
@@ -187,9 +187,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
 
                 var sites = await graphClient.Sites.Request(new List<Option>() {new QueryOption("search", "*")}).GetAsync();
                 
-                //var sites = await graphClient.Sites[$"{RootSiteId}"].Sites.Request().GetAsync();
-
-
                 Assert.IsNotNull(site);
             }
             catch (Microsoft.Graph.ServiceException e)

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
@@ -185,8 +185,6 @@ namespace Microsoft.Graph.Test.Requests.Functional
             {
                 Site site = await graphClient.Shares[UrlToSharingToken("https://m365x462896.sharepoint.com/sites/portals2")].Site.Request().GetAsync();
 
-                var sites = await graphClient.Sites.Request(new List<Option>() {new QueryOption("search", "*")}).GetAsync();
-                
                 Assert.IsNotNull(site);
             }
             catch (Microsoft.Graph.ServiceException e)

--- a/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/SharePointTests.cs
@@ -8,11 +8,11 @@ namespace Microsoft.Graph.Test.Requests.Functional
 {
     [Ignore]
     [TestClass]
-    public class SharePointTests : GraphTestBase
+    public class Given_a_valid_SharePoint_Site : GraphTestBase
     {
         // Test search a SharePoint site.
         [TestMethod]
-        public async Async.Task SharePointSearchSites()
+        public async Async.Task It_searches_the_SharePoint_Site_and_returns_results()
         {
             try
             {
@@ -34,9 +34,9 @@ namespace Microsoft.Graph.Test.Requests.Functional
             }
         }
 
-        // Test accessing the default document libraries for a SharePoint site.
+        // Test accessing the document libraries for a SharePoint site.
         [TestMethod]
-        public async Async.Task SharePointGetDocumentLibraries()
+        public async Async.Task It_gets_the_sites_drives()
         {
             try
             {
@@ -64,7 +64,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
 
         // Test accessing the non-default document library on a SharePoint site.
         [TestMethod]
-        public async Async.Task SharePointGetNonDefaultDocumentLibraries()
+        public async Async.Task It_gets_the_sites_drives_root_children()
         {
             try
             {
@@ -110,7 +110,7 @@ namespace Microsoft.Graph.Test.Requests.Functional
         /// 
         [Ignore] // Need reset test data  in demo tenant
         [TestMethod]
-        public async Async.Task SharePointGetSiteWithPath()
+        public async Async.Task It_gets_a_site_by_path()
         {
             try
             {
@@ -156,16 +156,40 @@ namespace Microsoft.Graph.Test.Requests.Functional
                 Assert.Fail("Something happened, check out a trace. Error code: {0}", e.Error.Code);
             }
         }
-        
+
+        /// <summary>
+        /// Test the custom 'Root' partial request builder.
+        /// </summary>
+        /// <returns></returns>
+        [TestMethod]
+        public async Async.Task It_gets_the_root_site()
+        {
+            try
+            {
+                Site site = await graphClient.Sites.Root.Request().GetAsync();
+                Assert.IsNotNull(site);
+            }
+            catch (Exception)
+            {
+                Assert.Fail("An unexpected exception was thrown. This test case failed.");
+            }
+        }
+
         /// <summary>
         /// Test to get information about a SharePoint site by its URL.
         /// </summary>
         [TestMethod]
-        public async Async.Task SharePointAccessSiteByUrl()
+        public async Async.Task It_gets_a_site_by_URL()
         {
             try
             {
                 Site site = await graphClient.Shares[UrlToSharingToken("https://m365x462896.sharepoint.com/sites/portals2")].Site.Request().GetAsync();
+
+                var sites = await graphClient.Sites.Request(new List<Option>() {new QueryOption("search", "*")}).GetAsync();
+                
+                //var sites = await graphClient.Sites[$"{RootSiteId}"].Sites.Request().GetAsync();
+
+
                 Assert.IsNotNull(site);
             }
             catch (Microsoft.Graph.ServiceException e)


### PR DESCRIPTION
Enables traversing a site's site hierarchy by using the root property. This allows a dev to find a site without needing to use GetByPath. This will make it easier to access a site's OneNote notebook.

@deepak2016 We will want to add the 'root' request builder property to enable this scenario for Java.