### PR TITLE
Adds cloning of HttpRequestMessage before retry

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/RequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/RequestExtensions.cs
@@ -5,6 +5,8 @@
 namespace Microsoft.Graph
 {
     using System.Net.Http;
+    using System.Threading.Tasks;
+
     /// <summary>
     /// Contains extension methods for <see cref="HttpRequestMessage"/>
     /// </summary>
@@ -25,6 +27,37 @@ namespace Microsoft.Graph
                 return false;
             }
             return true;
+        }
+
+        /// <summary>
+        /// Create a new HTTP request by copying previous HTTP request's headers and properties from response's request message.
+        /// </summary>
+        /// <param name="originalRequest">The previous <see cref="HttpRequestMessage"/> needs to be copy.</param>
+        /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
+        /// <remarks>
+        /// Re-issue a new HTTP request with the previous request's headers and properities
+        /// </remarks>
+        internal static async Task<HttpRequestMessage> CloneAsync(this HttpRequestMessage originalRequest)
+        {
+            var newRequest = new HttpRequestMessage(originalRequest.Method, originalRequest.RequestUri);
+
+            foreach (var header in originalRequest.Headers)
+            {
+                newRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+            }
+
+            foreach (var property in originalRequest.Properties)
+            {
+                newRequest.Properties.Add(property);
+            }
+
+            // Set Content if previous request contains
+            if (originalRequest.Content != null && originalRequest.Content.Headers.ContentLength != 0)
+            {
+                newRequest.Content = new StreamContent(await originalRequest.Content.ReadAsStreamAsync());
+            }
+
+            return newRequest;
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/AuthenticationHandler.cs
@@ -64,15 +64,16 @@ namespace Microsoft.Graph
             int retryAttempt = 0;
             while (retryAttempt < MaxRetry)
             {
-                var originalRequest = httpResponseMessage.RequestMessage;
+                // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
+                var newRequest = await httpResponseMessage.RequestMessage.CloneAsync();
 
                 // Authenticate request using AuthenticationProvider
-                await AuthenticationProvider.AuthenticateRequestAsync(originalRequest);
-                httpResponseMessage = await base.SendAsync(originalRequest, cancellationToken);
+                await AuthenticationProvider.AuthenticateRequestAsync(newRequest);
+                httpResponseMessage = await base.SendAsync(newRequest, cancellationToken);
 
                 retryAttempt++;
 
-                if (!IsUnauthorized(httpResponseMessage) || !originalRequest.IsBuffered())
+                if (!IsUnauthorized(httpResponseMessage) || !newRequest.IsBuffered())
                 {
                     // Re-issue the request to get a new access token
                     return httpResponseMessage;

--- a/src/Microsoft.Graph.Core/Requests/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/RedirectHandler.cs
@@ -65,8 +65,8 @@ namespace Microsoft.Graph
 
                 while (redirectCount < maxRedirects)
                 {
-                    // general copy request with internal CopyRequest(see copyRequest for details) method 
-                    var newRequest = await CopyRequest(response.RequestMessage);
+                    // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
+                    var newRequest = await response.RequestMessage.CloneAsync();
 
                     // status code == 303: change request method from post to get and content to be null
                     if (response.StatusCode == HttpStatusCode.SeeOther)
@@ -105,37 +105,6 @@ namespace Microsoft.Graph
             }
             return response;
 
-        }
-
-        /// <summary>
-        /// Create a new HTTP request by copying previous HTTP request's headers and properties from response's request message.
-        /// </summary>
-        /// <param name="originalRequest">The previous <see cref="HttpRequestMessage"/> needs to be copy.</param>
-        /// <returns>The <see cref="HttpRequestMessage"/>.</returns>
-        /// <remarks>
-        /// Re-issue a new HTTP request with the previous request's headers and properities
-        /// </remarks>
-        internal async Task<HttpRequestMessage> CopyRequest(HttpRequestMessage originalRequest)
-        {
-            var newRequest = new HttpRequestMessage(originalRequest.Method, originalRequest.RequestUri);
-
-            foreach (var header in originalRequest.Headers)
-            {
-                newRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
-            }
-
-            foreach (var property in originalRequest.Properties)
-            {
-                newRequest.Properties.Add(property);
-            }    
-
-            // Set Content if previous request contains
-            if (originalRequest.Content != null && originalRequest.Content.Headers.ContentLength != 0)
-            {
-                newRequest.Content = new StreamContent(await originalRequest.Content.ReadAsStreamAsync());
-            }
-
-            return newRequest;
         }
 
 

--- a/src/Microsoft.Graph.Core/Requests/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/RetryHandler.cs
@@ -71,19 +71,15 @@ namespace Microsoft.Graph
         /// <returns></returns>
         public async Task<HttpResponseMessage> SendRetryAsync(HttpResponseMessage response, CancellationToken cancellationToken)
         {
-
-
             int retryCount = 0;
 
-          
             while (retryCount < MaxRetry)
             {
-
                 // Call Delay method to get delay time from response's Retry-After header or by exponential backoff 
                 Task delay = Delay(response, retryCount, cancellationToken);
 
-                // Get the original request
-                var request = response.RequestMessage;
+                // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
+                var request = await response.RequestMessage.CloneAsync();
 
                 // Increase retryCount and then update Retry-Attempt in request header
                 retryCount++;
@@ -110,8 +106,6 @@ namespace Microsoft.Graph
 
         }
 
-
-
         /// <summary>
         /// Check the HTTP response's status to determine whether it should be retried or not.
         /// </summary>
@@ -126,7 +120,6 @@ namespace Microsoft.Graph
             }
             return false;
         }
-
 
         /// <summary>
         /// Update Retry-Attempt header in the HTTP request

--- a/tests/Microsoft.Graph.Core.Test/Requests/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/AuthenticationHandlerTests.cs
@@ -71,8 +71,8 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
-            Assert.AreSame(response, expectedResponse, "Doesn't return a successful response");
-            Assert.AreSame(response.RequestMessage, httpRequestMessage, "Http response message sets wrong request message");
+            Assert.AreSame(response, expectedResponse, "Doesn't return a successful response.");
+            Assert.AreSame(response.RequestMessage, httpRequestMessage, "Reissued a new http request.");
         }
 
         [TestMethod]
@@ -86,9 +86,9 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
-            Assert.AreSame(response.RequestMessage, httpRequestMessage, "Http response message sets wrong request message");
-            Assert.AreSame(response, expectedResponse, "Retry didn't happen");
-            Assert.IsNull(response.RequestMessage.Content, "Content is not null");
+            Assert.AreNotSame(response.RequestMessage, httpRequestMessage, "Doesn't reissue a new http request.");
+            Assert.AreSame(response, expectedResponse, "Retry didn't happen.");
+            Assert.IsNull(response.RequestMessage.Content, "Content is not null.");
         }
 
         [TestMethod]
@@ -102,9 +102,9 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
-            Assert.AreSame(response.RequestMessage, httpRequestMessage, "Http response message sets wrong request message");
-            Assert.AreSame(response, expectedResponse, "Retry didn't happen");
-            Assert.IsNull(response.RequestMessage.Content, "Content is not null");
+            Assert.AreNotSame(response.RequestMessage, httpRequestMessage, "Doesn't reissue a new http request.");
+            Assert.AreSame(response, expectedResponse, "Retry didn't happen.");
+            Assert.IsNull(response.RequestMessage.Content, "Content is not null.");
         }
 
         [TestMethod]
@@ -120,10 +120,11 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
-            Assert.AreSame(response, okResponse, "Retry didn't happen");
-            Assert.AreNotSame(response, unauthorizedResponse, "Retry didn't happen");
-            Assert.IsNotNull(response.RequestMessage.Content, "The request content is null");
-            Assert.AreEqual(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello World!", "Content changed");
+            Assert.AreNotSame(response.RequestMessage, httpRequestMessage, "Doesn't reissue a new http request.");
+            Assert.AreSame(response, okResponse, "Retry didn't happen.");
+            Assert.AreNotSame(response, unauthorizedResponse, "Retry didn't happen.");
+            Assert.IsNotNull(response.RequestMessage.Content, "The request content is null.");
+            Assert.AreEqual(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello World!", "Content changed.");
         }
 
         [TestMethod]
@@ -139,10 +140,11 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
-            Assert.AreSame(response, okResponse, "Retry didn't happen");
-            Assert.AreNotSame(response, unauthorizedResponse, "Retry didn't happen");
-            Assert.IsNotNull(response.RequestMessage.Content, "The request content is null");
-            Assert.AreEqual(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello World!", "Content changed");
+            Assert.AreNotSame(response.RequestMessage, httpRequestMessage, "Doesn't reissue a new http request.");
+            Assert.AreSame(response, okResponse, "Retry didn't happen.");
+            Assert.AreNotSame(response, unauthorizedResponse, "Retry didn't happen.");
+            Assert.IsNotNull(response.RequestMessage.Content, "The request content is null.");
+            Assert.AreEqual(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello World!", "Content changed.");
         }
 
         [TestMethod]
@@ -159,10 +161,11 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
-            Assert.AreNotSame(response, okResponse, "Unexpected retry");
-            Assert.AreSame(response, unauthorizedResponse, "Unexpected retry");
-            Assert.IsNotNull(response.RequestMessage.Content, "Request content is null");
-            Assert.AreEqual(response.RequestMessage.Content.Headers.ContentLength, -1, "Request content length changed");
+            Assert.AreSame(response.RequestMessage, httpRequestMessage, "Reissued a new http request.");
+            Assert.AreNotSame(response, okResponse, "Unexpected retry.");
+            Assert.AreSame(response, unauthorizedResponse, "Unexpected retry.");
+            Assert.IsNotNull(response.RequestMessage.Content, "Request content is null.");
+            Assert.AreEqual(response.RequestMessage.Content.Headers.ContentLength, -1, "Request content length changed.");
         }
 
         [TestMethod]
@@ -179,10 +182,11 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
-            Assert.AreNotSame(response, okResponse, "Unexpected retry");
-            Assert.AreSame(response, unauthorizedResponse, "Unexpected retry");
-            Assert.IsNotNull(response.RequestMessage.Content, "Request content is null");
-            Assert.AreEqual(response.RequestMessage.Content.Headers.ContentLength, -1, "Request content length changed");
+            Assert.AreSame(response.RequestMessage, httpRequestMessage, "Reissued a new http request.");
+            Assert.AreNotSame(response, okResponse, "Unexpected retry.");
+            Assert.AreSame(response, unauthorizedResponse, "Unexpected retry.");
+            Assert.IsNotNull(response.RequestMessage.Content, "Request content is null.");
+            Assert.AreEqual(response.RequestMessage.Content.Headers.ContentLength, -1, "Request content length changed.");
         }
 
         [TestMethod]
@@ -197,7 +201,8 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
-            Assert.AreSame(response, expectedResponse, "Unexpected code returned");
+            Assert.AreNotSame(response.RequestMessage, httpRequestMessage, "Doesn't reissued a new http request.");
+            Assert.AreSame(response, expectedResponse, "Unexpected code returned.");
             Assert.AreEqual(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello Mars!");
         }
     }

--- a/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -206,9 +206,10 @@ namespace Microsoft.Graph.Core.Test.Requests
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, response_2);
                 IEnumerable<string> values;
-                Assert.IsTrue(httpRequestMessage.Headers.TryGetValues("Retry-Attempt", out values), "Don't set Retry-Attemp Header");
+                Assert.IsTrue(response.RequestMessage.Headers.TryGetValues("Retry-Attempt", out values), "Don't set Retry-Attemp Header");
                 Assert.AreEqual(values.Count(), 1);
                 Assert.AreEqual(values.First(), 1.ToString());
+                Assert.AreNotSame(response.RequestMessage, httpRequestMessage);
             }
         }
 
@@ -251,7 +252,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, okResponse);
-                Assert.AreSame(response.RequestMessage, httpRequestMessage);
+                Assert.AreNotSame(response.RequestMessage, httpRequestMessage);
             }
         }
 

--- a/tests/Microsoft.Graph.Core.Test/Requests/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/RetryHandlerTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
             Assert.AreSame(response, response_2, "Retry failed.");
-            Assert.AreSame(response.RequestMessage, httpRequestMessage, "The request is set wrong.");
+            Assert.AreNotSame(response.RequestMessage, httpRequestMessage, "The request is set wrong.");
             Assert.IsNotNull(response.RequestMessage.Headers, "The request header is null");
             Assert.IsTrue(response.RequestMessage.Headers.Contains(RETRY_ATTEMPT), "Doesn't set Retry-Attemp header to request");
             IEnumerable<string> values;
@@ -227,7 +227,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             Assert.AreSame(response, response_2);
             IEnumerable<string> values;
-            Assert.IsTrue(httpRequestMessage.Headers.TryGetValues(RETRY_ATTEMPT, out values), "Don't set Retry-Attemp Header");
+            Assert.IsTrue(response.RequestMessage.Headers.TryGetValues(RETRY_ATTEMPT, out values), "Don't set Retry-Attemp Header");
             Assert.AreEqual(values.Count(), 1);
             Assert.AreEqual(values.First(), 1.ToString());
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/AuthenticationHandlerTests.cs
@@ -83,7 +83,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
             Assert.Same(response, expectedResponse);
-            Assert.Same(response.RequestMessage, httpRequestMessage);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
             Assert.Null(response.RequestMessage.Content);
         }
 
@@ -98,6 +98,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
             Assert.Same(response, expectedResponse);
             Assert.NotSame(response, unauthorizedResponse);
             Assert.Null(response.RequestMessage.Content);
@@ -116,6 +117,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
             Assert.Same(response, okResponse);
             Assert.NotSame(response, unauthorizedResponse);
             Assert.NotNull(response.RequestMessage.Content);
@@ -135,6 +137,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
             Assert.Same(response, okResponse);
             Assert.NotSame(response, unauthorizedResponse);
             Assert.NotNull(response.RequestMessage.Content);
@@ -155,6 +158,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
+            Assert.Same(response.RequestMessage, httpRequestMessage);
             Assert.NotSame(response, okResponse);
             Assert.Same(response, unauthorizedResponse);
             Assert.NotNull(response.RequestMessage.Content);
@@ -175,6 +179,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
+            Assert.Same(response.RequestMessage, httpRequestMessage);
             Assert.NotSame(response, okResponse);
             Assert.Same(response, unauthorizedResponse);
             Assert.NotNull(response.RequestMessage.Content);
@@ -194,6 +199,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
             Assert.Same(response, expectedResponse);
             Assert.Equal(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello Mars!");
         }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.Same(response, response_2);
                 IEnumerable<string> values;
-                Assert.True(httpRequestMessage.Headers.TryGetValues("Retry-Attempt", out values), "Don't set Retry-Attemp Header");
+                Assert.True(response.RequestMessage.Headers.TryGetValues("Retry-Attempt", out values), "Don't set Retry-Attemp Header");
                 Assert.Equal(values.Count(), 1);
                 Assert.Equal(values.First(), 1.ToString());
             }
@@ -253,7 +253,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.Same(response, okResponse);
-                Assert.Same(response.RequestMessage, httpRequestMessage);
+                Assert.NotSame(response.RequestMessage, httpRequestMessage);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/RetryHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/RetryHandlerTests.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
             Assert.Same(response, response_2);
-            Assert.Same(response.RequestMessage, httpRequestMessage);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
             Assert.NotNull(response.RequestMessage.Headers);
             Assert.True(response.RequestMessage.Headers.Contains(RETRY_ATTEMPT));
             IEnumerable<string> values;
@@ -114,6 +114,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
             Assert.Same(response, response_2);
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
             Assert.NotNull(response.RequestMessage.Content);
             Assert.NotNull(response.RequestMessage.Content.Headers.ContentLength);
             Assert.Equal(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello World");
@@ -139,6 +140,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             Assert.NotEqual(response, response_2);
             Assert.Same(response, retryResponse);
+            Assert.Same(response.RequestMessage, httpRequestMessage);
             Assert.NotNull(response.RequestMessage.Content);
             Assert.NotNull(response.RequestMessage.Content.Headers.ContentLength);
             Assert.Equal(response.RequestMessage.Content.Headers.ContentLength, -1);
@@ -164,6 +166,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var response = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
 
             Assert.NotEqual(response, response_2);
+            Assert.Same(response.RequestMessage, httpRequestMessage);
             Assert.Same(response, retryResponse);
             Assert.NotNull(response.RequestMessage.Content);
             Assert.Null(response.RequestMessage.Content.Headers.ContentLength);
@@ -250,11 +253,10 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             Assert.Same(response, response_2);
             IEnumerable<string> values;
-            Assert.True(httpRequestMessage.Headers.TryGetValues(RETRY_ATTEMPT, out values), "Don't set Retry-Attemp Header");
+            Assert.True(response.RequestMessage.Headers.TryGetValues(RETRY_ATTEMPT, out values), "Don't set Retry-Attempt Header");
             Assert.Equal(values.Count(), 1);
             Assert.Equal(values.First(), 1.ToString());
-           
-
+            Assert.NotSame(response.RequestMessage, httpRequestMessage);
         }
 
         private async Task DelayTestWithMessage(HttpResponseMessage response, int count, string message)


### PR DESCRIPTION
C#'s HttpClient doesn't allow re-issuing of the same HttpRequestMessage as referenced [here](https://stackoverflow.com/questions/18000583/re-send-httprequestmessage-exception).

This PR adds the following changes to support the above:
- Adds an internal **CloneAsync** extension method to **HttpRequestMessage**.
- Updates the delegating handlers to use the CloneAsync method when performing a retry.
- Updates tests to consider the above changes.