### PR TITLE
National cloud Auth Provider Factory PoC

### DIFF
--- a/src/Microsoft.Graph.Core/CoreConstants.cs
+++ b/src/Microsoft.Graph.Core/CoreConstants.cs
@@ -51,5 +51,13 @@ namespace Microsoft.Graph
             /// OData type
             public const string ODataType = "@odata.type";
         }
+
+        public static class NationalClouds
+        {
+            public const string China = "Mooncake";
+            public const string Germany = "BlackForest";
+            public const string USGov = "Fairfax";
+            public const string Global = "Global";
+        }
     }
 }

--- a/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/BaseRequestExtensions.cs
@@ -43,19 +43,20 @@ namespace Microsoft.Graph
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="baseRequest">The <see cref="BaseRequest"/> for the request.</param>
+        /// <param name="username">A username in a UPN format used to identify the right national cloud authentication provider for the user.</param>
         /// <returns></returns>
-        public static T WithPerRequestAuthProvider<T>(this T baseRequest) where T : IBaseRequest
+        public static T WithPerRequestAuthProvider<T>(this T baseRequest, string username = null) where T : IBaseRequest
         {
             if (baseRequest.Client.PerRequestAuthProvider != null)
             {
                 string authOptionKey = typeof(AuthOption).ToString();
                 if (baseRequest.MiddlewareOptions.ContainsKey(authOptionKey))
                 {
-                    (baseRequest.MiddlewareOptions[authOptionKey] as AuthOption).AuthenticationProvider = baseRequest.Client.PerRequestAuthProvider();
+                    (baseRequest.MiddlewareOptions[authOptionKey] as AuthOption).AuthenticationProvider = baseRequest.Client.PerRequestAuthProvider(username);
                 }
                 else
                 {
-                    baseRequest.MiddlewareOptions.Add(authOptionKey, new AuthOption { AuthenticationProvider = baseRequest.Client.PerRequestAuthProvider() });
+                    baseRequest.MiddlewareOptions.Add(authOptionKey, new AuthOption { AuthenticationProvider = baseRequest.Client.PerRequestAuthProvider(username) });
                 }
             }
             return baseRequest;

--- a/src/Microsoft.Graph.Core/Models/OpenIdConfiguration.cs
+++ b/src/Microsoft.Graph.Core/Models/OpenIdConfiguration.cs
@@ -1,0 +1,76 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Graph
+{
+    public class OpenIdConfiguration
+    {
+        [JsonProperty("authorization_endpoint")]
+        public Uri AuthorizationEndpoint { get; set; }
+
+        [JsonProperty("token_endpoint")]
+        public Uri TokenEndpoint { get; set; }
+
+        [JsonProperty("token_endpoint_auth_methods_supported")]
+        public List<string> TokenEndpointAuthMethodsSupported { get; set; }
+
+        [JsonProperty("jwks_uri")]
+        public Uri JwksUri { get; set; }
+
+        [JsonProperty("response_modes_supported")]
+        public List<string> ResponseModesSupported { get; set; }
+
+        [JsonProperty("subject_types_supported")]
+        public List<string> SubjectTypesSupported { get; set; }
+
+        [JsonProperty("id_token_signing_alg_values_supported")]
+        public List<string> IdTokenSigningAlgValuesSupported { get; set; }
+
+        [JsonProperty("http_logout_supported")]
+        public bool HttpLogoutSupported { get; set; }
+
+        [JsonProperty("frontchannel_logout_supported")]
+        public bool FrontchannelLogoutSupported { get; set; }
+
+        [JsonProperty("end_session_endpoint")]
+        public Uri EndSessionEndpoint { get; set; }
+
+        [JsonProperty("response_types_supported")]
+        public List<string> ResponseTypesSupported { get; set; }
+
+        [JsonProperty("scopes_supported")]
+        public List<string> ScopesSupported { get; set; }
+
+        [JsonProperty("issuer")]
+        public Uri Issuer { get; set; }
+
+        [JsonProperty("claims_supported")]
+        public List<string> ClaimsSupported { get; set; }
+
+        [JsonProperty("request_uri_parameter_supported")]
+        public bool RequestUriParameterSupported { get; set; }
+
+        [JsonProperty("userinfo_endpoint")]
+        public Uri UserinfoEndpoint { get; set; }
+
+        [JsonProperty("tenant_region_scope")]
+        public string TenantRegionScope { get; set; }
+
+        [JsonProperty("tenant_region_sub_scope")]
+        public string TenantRegionSubScope { get; set; }
+
+        [JsonProperty("cloud_instance_name")]
+        public string CloudInstanceName { get; set; }
+
+        [JsonProperty("cloud_graph_host_name")]
+        public string CloudGraphHostName { get; set; }
+
+        [JsonProperty("msgraph_host")]
+        public string MsgraphHost { get; set; }
+
+        [JsonProperty("rbac_url")]
+        public Uri RbacUrl { get; set; }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/BaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseClient.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Graph
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// A default <see cref="IBaseClient"/> implementation.
@@ -64,6 +65,6 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets or Sets the <see cref="IAuthenticationProvider"/> for authenticating a single HTTP requests. 
         /// </summary>
-        public Func<IAuthenticationProvider> PerRequestAuthProvider { get; set; }
+        public Func<string, IAuthenticationProvider> PerRequestAuthProvider { get; set; }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
+++ b/src/Microsoft.Graph.Core/Requests/IBaseClient.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Graph
 {
     using System;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// Interface for the base client.
@@ -29,6 +30,6 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets or Sets the <see cref="IAuthenticationProvider"/> for authenticating a single HTTP requests. 
         /// </summary>
-        Func<IAuthenticationProvider> PerRequestAuthProvider { get; set; }
+        Func<string, IAuthenticationProvider> PerRequestAuthProvider { get; set; }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/Providers/IGraphStorageProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/Providers/IGraphStorageProvider.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
 
 namespace Microsoft.Graph
 {
+    using System.Threading.Tasks;
+    /// <summary>
+    /// An IGraphStorageProvider interface
+    /// </summary>
     public interface IGraphStorageProvider
     {
         Task SetStorageItemAsync(string itemId, object item);

--- a/src/Microsoft.Graph.Core/Requests/Providers/IGraphStorageProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/Providers/IGraphStorageProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Graph
+{
+    public interface IGraphStorageProvider
+    {
+        Task SetStorageItemAsync(string itemId, object item);
+        Task<object> GetStorageItemAsync(string itemId);
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Providers/NationalCloudAuthProviderFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/Providers/NationalCloudAuthProviderFactory.cs
@@ -1,0 +1,89 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading.Tasks;
+using static Microsoft.Graph.CoreConstants;
+
+namespace Microsoft.Graph
+{
+    public class NationalCloudAuthProviderFactory
+    {
+        private Dictionary<string, Func<IAuthenticationProvider>> _authProviders;
+        private IGraphStorageProvider _graphStorageProvider;
+        private const string _nationalCloudCacheKey = "graph_national_cloud";
+        public NationalCloudAuthProviderFactory(IGraphStorageProvider graphStorageProvider)
+        {
+            _authProviders = new Dictionary<string, Func<IAuthenticationProvider>>();
+            _graphStorageProvider = graphStorageProvider;
+        }
+
+        public void AddProvider(string nationalCloud, IAuthenticationProvider authenticationProvider)
+        {
+            _authProviders.Add(nationalCloud, () => authenticationProvider);
+        }
+
+        public void AddProvider(string nationalCloud, Func<IAuthenticationProvider> authenticationProvider)
+        {
+            _authProviders.Add(nationalCloud, authenticationProvider);
+        }
+
+        public async Task<IAuthenticationProvider> GetProviderForUserAsync(string domainIdentifier)
+        {
+            if (string.IsNullOrEmpty(domainIdentifier)) return null;
+
+            int atIndex = domainIdentifier.IndexOf('@');
+            string usersDomain = string.Empty;
+
+            if (atIndex != -1)
+                usersDomain = domainIdentifier.Substring(atIndex + 1);
+            else
+                usersDomain = domainIdentifier;
+
+            // check if tenant is in our cache
+            string nationalCloudCache = (await _graphStorageProvider.GetStorageItemAsync(usersDomain + _nationalCloudCacheKey)) as string;
+
+            if (nationalCloudCache == null)
+                // if null, get openid config
+                nationalCloudCache = await GetDomainNationalCloudAsync(usersDomain);
+
+            _authProviders.TryGetValue(nationalCloudCache, out Func<IAuthenticationProvider> authenticationProviderDelegate);
+
+            return authenticationProviderDelegate?.Invoke();
+        }
+
+        private async Task<string> GetDomainNationalCloudAsync(string usersDomain)
+        {
+            string nationalCloud = CoreConstants.NationalClouds.Global;
+            // if not, is it mooncake?
+            if (usersDomain.EndsWith(".cn"))
+                nationalCloud = NationalClouds.China;
+            else
+            {
+                HttpClient httpClient = new HttpClient();
+                var response = await httpClient.GetAsync("https://login.microsoftonline.com/" + usersDomain + "/v2.0/.well-known/openid-configuration");
+
+                // get openid config
+                string responseString = await response.Content.ReadAsStringAsync();
+
+                OpenIdConfiguration openIdConfig = JsonConvert.DeserializeObject<OpenIdConfiguration>(responseString);
+
+                switch (openIdConfig.CloudInstanceName)
+                {
+                    case "microsoftonline.de":
+                        nationalCloud = NationalClouds.Germany;
+                        break;
+                    case "microsoftonline.us":
+                        if (openIdConfig.TenantRegionSubScope != "DODC")
+                            nationalCloud = NationalClouds.USGov;
+                        break;
+                    case "microsoftonline.com":
+                        if (openIdConfig.TenantRegionSubScope == "USG" || openIdConfig.TenantRegionSubScope == "DODC")
+                            nationalCloud = NationalClouds.USGov;
+                        break;
+                }
+            }
+            return nationalCloud;
+        }
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/Providers/NationalCloudAuthProviderFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/Providers/NationalCloudAuthProviderFactory.cs
@@ -1,33 +1,56 @@
-﻿using Newtonsoft.Json;
-using System;
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Threading.Tasks;
-using static Microsoft.Graph.CoreConstants;
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
 
 namespace Microsoft.Graph
 {
+    using Newtonsoft.Json;
+    using System;
+    using System.Collections.Generic;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using static Microsoft.Graph.CoreConstants;
+
     public class NationalCloudAuthProviderFactory
     {
         private Dictionary<string, Func<IAuthenticationProvider>> _authProviders;
         private IGraphStorageProvider _graphStorageProvider;
         private const string _nationalCloudCacheKey = "graph_national_cloud";
-        public NationalCloudAuthProviderFactory(IGraphStorageProvider graphStorageProvider)
+        /// <summary>
+        /// Create a new NationalCloudAuthProviderFactory
+        /// </summary>
+        /// <param name="graphStorageProvider">An optional storage provider to store mapping of domains to national clouds</param>
+        public NationalCloudAuthProviderFactory(IGraphStorageProvider graphStorageProvider = null)
         {
             _authProviders = new Dictionary<string, Func<IAuthenticationProvider>>();
-            _graphStorageProvider = graphStorageProvider;
+            _graphStorageProvider = graphStorageProvider ?? new StaticGraphStorageProvider();
         }
 
+        /// <summary>
+        /// Adds an <see cref="IAuthenticationProvider"/> that's configured for a national cloud.
+        /// </summary>
+        /// <param name="nationalCloud">The national cloud for the auth provider.</param>
+        /// <param name="authenticationProvider">An auth provider configured for the national cloud.</param>
         public void AddProvider(string nationalCloud, IAuthenticationProvider authenticationProvider)
         {
             _authProviders.Add(nationalCloud, () => authenticationProvider);
         }
 
+        /// <summary>
+        /// Adds an <see cref="IAuthenticationProvider"/> that's configured for a national cloud.
+        /// </summary>
+        /// <param name="nationalCloud">The national cloud for the auth provider.</param>
+        /// <param name="authenticationProvider">A delegate that returns an auth provider configured for the national cloud.</param>
         public void AddProvider(string nationalCloud, Func<IAuthenticationProvider> authenticationProvider)
         {
             _authProviders.Add(nationalCloud, authenticationProvider);
         }
 
+        /// <summary>
+        /// Gets an auth provider configured to a user or tenant national cloud.
+        /// </summary>
+        /// <param name="domainIdentifier">A UserPrincipalName or tenantDomain that will be used to get a national cloud.</param>
+        /// <returns></returns>
         public async Task<IAuthenticationProvider> GetProviderForUserAsync(string domainIdentifier)
         {
             if (string.IsNullOrEmpty(domainIdentifier)) return null;

--- a/src/Microsoft.Graph.Core/Requests/Providers/StaticGraphStorageProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/Providers/StaticGraphStorageProvider.cs
@@ -1,11 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
 
 namespace Microsoft.Graph
 {
-    public class StaticGraphStorageProvider : IGraphStorageProvider
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    internal class StaticGraphStorageProvider : IGraphStorageProvider
     {
         private static IDictionary<string, object> _cache = new Dictionary<string, object>();
         public async Task<object> GetStorageItemAsync(string itemId)

--- a/src/Microsoft.Graph.Core/Requests/Providers/StaticGraphStorageProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/Providers/StaticGraphStorageProvider.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Graph
+{
+    public class StaticGraphStorageProvider : IGraphStorageProvider
+    {
+        private static IDictionary<string, object> _cache = new Dictionary<string, object>();
+        public async Task<object> GetStorageItemAsync(string itemId)
+        {
+            _cache.TryGetValue(itemId, out object item);
+
+            return await Task.FromResult(item);
+        }
+
+        public async Task SetStorageItemAsync(string itemId, object item)
+        {
+            _cache.Add(itemId, item);
+
+            await Task.FromResult(0);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
+++ b/tests/Microsoft.Graph.Test/Microsoft.Graph.Test.csproj
@@ -107,6 +107,7 @@
     <Compile Include="Requests\Functional\GraphTestBase.cs" />
     <Compile Include="Requests\Functional\GroupTests.cs" />
     <Compile Include="Requests\Functional\MailTests.cs" />
+    <Compile Include="Requests\Functional\NationalCloudTests.cs" />
     <Compile Include="Requests\Functional\OneDriveTests.cs" />
     <Compile Include="Requests\Functional\ErrorTests.cs" />
     <Compile Include="Requests\Functional\DeltaQueryTests.cs" />
@@ -130,6 +131,7 @@
     <Compile Include="Requests\RequestTestBase.cs" />
     <Compile Include="Models\ModelSerializationTests.cs" />
     <Compile Include="Requests\Functional\ExcelTests.cs" />
+    <Compile Include="Requests\TestAuthProvider.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.Graph.Core\Microsoft.Graph.Core.csproj">

--- a/tests/Microsoft.Graph.Test/Requests/Functional/NationalCloudTests.cs
+++ b/tests/Microsoft.Graph.Test/Requests/Functional/NationalCloudTests.cs
@@ -1,0 +1,31 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Test.Requests.Functional
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Threading.Tasks;
+    using static Microsoft.Graph.CoreConstants;
+
+    [Ignore]
+    [TestClass]
+    public class NationalCloudTests: GraphTestBase
+    {
+        // Tests the GetProviderForUserAsync.
+        [TestMethod]
+        public async Task GetProviderForUser()
+        {
+            var providerFactory = new NationalCloudAuthProviderFactory();
+            providerFactory.AddProvider(NationalClouds.Global, () => new TestAuthProvider(NationalClouds.Global));
+            providerFactory.AddProvider(NationalClouds.China, () => new TestAuthProvider(NationalClouds.China));
+            providerFactory.AddProvider(NationalClouds.Germany, () => new TestAuthProvider(NationalClouds.Germany));
+            providerFactory.AddProvider(NationalClouds.USGov, () => new TestAuthProvider(NationalClouds.USGov));
+
+            IAuthenticationProvider authProvider = await providerFactory.GetProviderForUserAsync("<UPN or tenant domain>");
+
+            Assert.IsNotNull(authProvider);
+            Assert.AreEqual((authProvider as TestAuthProvider).CloudName, NationalClouds.Global);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.Test/Requests/TestAuthProvider.cs
+++ b/tests/Microsoft.Graph.Test/Requests/TestAuthProvider.cs
@@ -1,0 +1,22 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Test.Requests
+{
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    public class TestAuthProvider : IAuthenticationProvider
+    {
+        public string CloudName { get; private set; }
+
+        public TestAuthProvider(string cloudName)
+        {
+            CloudName = cloudName;
+        }
+        public async Task AuthenticateRequestAsync(HttpRequestMessage request)
+        {
+            await Task.FromResult(0);
+        }
+    }
+}


### PR DESCRIPTION
This PR contains a PoC implementation of National Cloud support in the client library.

### Adds
- **NationalCloudAuthProviderFactory** which is used to get & set the right pre-configured auth provider for a user or domain tenant.
- **WithPerRequestAuthProvider** extension method to set a users UPN or domain tenant which will be used to identify the right national cloud aware provider.
- Adds **NationalCloudTests** funtional test to test the PoC.

### Proposed Usage
```csharp
// Create graph client with the default auth provider. This will be the fallback provider if the factory can't find a users cloud.
var graphClient = new GraphServiceClient(appOnlyProvider, httpProvider);

// Configure auth providers for the supported cloud i.e,
var providerFactory = new NationalCloudAuthProviderFactory();
providerFactory.AddProvider(NationalClouds.Germany, new OnBehalfOfProvider(...));
providerFactory.AddProvider(NationalClouds.China, new OnBehalfOfProvider(...));
providerFactory.AddProvider(NationalClouds.UsGov, () => new OnBehalfOfProvider(...));

// Tell graph client to use cloud aware provider for this request
graphClient.PerRequestAuthProvider = providerFactory.GetProviderForUser; // cloud aware provider
 
// Use the right auth provider based on the users UPN 
var me = await graphClient.Me.Request()
.WithPerRequestAuthProvider(userPrincipalName) // we will figure out the users cloud aware provider
.GetAsync();
```