### PR TITLE
Refactored response handling out of baseRequest

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -20,6 +20,8 @@ namespace Microsoft.Graph
     /// </summary>
     public class BaseRequest : IBaseRequest
     {
+        private ResponseHandler responseHandler;
+
         /// <summary>
         /// Constructs a new <see cref="BaseRequest"/>.
         /// </summary>
@@ -33,6 +35,7 @@ namespace Microsoft.Graph
         {
             this.Method = "GET";
             this.Client = client;
+            this.responseHandler = new ResponseHandler(client.HttpProvider.Serializer);
             this.Headers = new List<HeaderOption>();
             this.QueryOptions = new List<QueryOption>();
             this.MiddlewareOptions = new Dictionary<string, IMiddlewareOption>();
@@ -125,16 +128,10 @@ namespace Microsoft.Graph
         {
             using (var response = await this.SendRequestAsync(serializableObject, cancellationToken, completionOption).ConfigureAwait(false))
             {
-                if (response.Content != null)
-                {
-                    var responseString = await GetResponseString(response);
-                    return this.Client.HttpProvider.Serializer.DeserializeObject<T>(responseString);
-                }
-
-                return default(T);
+                return await this.responseHandler.HandleResponse<T>(response);
             }
         }
-
+        
         /// <summary>
         /// Sends the multipart request.
         /// </summary>
@@ -150,13 +147,7 @@ namespace Microsoft.Graph
         {
             using (var response = await this.SendMultiPartRequestAsync(multipartContent, cancellationToken, completionOption).ConfigureAwait(false))
             {
-                if (response.Content != null)
-                {
-                    var responseString = await GetResponseString(response);
-                    return this.Client.HttpProvider.Serializer.DeserializeObject<T>(responseString);
-                }
-
-                return default(T);
+                return await this.responseHandler.HandleResponse<T>(response);
             }
         }
 
@@ -409,33 +400,6 @@ namespace Microsoft.Graph
             return new UriBuilder(uri) { Query = string.Empty }.ToString();
         }
 
-        /// <summary>
-        /// Get the response content string
-        /// </summary>
-        /// <param name="hrm">The response object</param>
-        /// <returns>The full response string to return</returns>
-        private async Task<string> GetResponseString(HttpResponseMessage hrm)
-        {
-            var responseContent = "";
-
-            var content = await hrm.Content.ReadAsStringAsync().ConfigureAwait(false);
-
-            //Only add headers if we are going to return a response body
-            if (content.Length > 0)
-            {
-                var responseHeaders = hrm.Headers;
-                var statusCode = hrm.StatusCode;
-
-                Dictionary<string, string[]> headerDictionary = responseHeaders.ToDictionary(x => x.Key, x => x.Value.ToArray());
-                var responseHeaderString = this.Client.HttpProvider.Serializer.SerializeObject(headerDictionary);
-
-                responseContent = content.Substring(0, content.Length - 1) + ", ";
-                responseContent += "\"responseHeaders\": " + responseHeaderString + ", ";
-                responseContent += "\"statusCode\": \"" + statusCode + "\"}";
-            }
-
-            return responseContent;
-        }
 
         /// <summary>
         /// Gets a specified header value from <see cref="HttpRequestMessage"/>

--- a/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
@@ -1,0 +1,61 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+
+    public class ResponseHandler
+    {
+        private readonly ISerializer serializer;
+
+        public ResponseHandler(ISerializer serializer)
+        {
+            this.serializer = serializer;
+        }
+
+        public async Task<T> HandleResponse<T>(HttpResponseMessage response)
+        {
+            if (response.Content != null)
+            {
+                var responseString = await GetResponseString(response);
+                return serializer.DeserializeObject<T>(responseString);
+            }
+
+            return default(T);
+        }
+
+        /// <summary>
+        /// Get the response content string
+        /// </summary>
+        /// <param name="hrm">The response object</param>
+        /// <returns>The full response string to return</returns>
+        private async Task<string> GetResponseString(HttpResponseMessage hrm)
+        {
+            var responseContent = "";
+
+            var content = await hrm.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+            //Only add headers if we are going to return a response body
+            if (content.Length > 0)
+            {
+                var responseHeaders = hrm.Headers;
+                var statusCode = hrm.StatusCode;
+
+                Dictionary<string, string[]> headerDictionary = responseHeaders.ToDictionary(x => x.Key, x => x.Value.ToArray());
+                var responseHeaderString = serializer.SerializeObject(headerDictionary);
+
+                responseContent = content.Substring(0, content.Length - 1) + ", ";
+                responseContent += "\"responseHeaders\": " + responseHeaderString + ", ";
+                responseContent += "\"statusCode\": \"" + statusCode + "\"}";
+            }
+
+            return responseContent;
+        }
+
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/ResponseHandler.cs
@@ -18,6 +18,12 @@ namespace Microsoft.Graph
             this.serializer = serializer;
         }
 
+        /// <summary>
+        /// Process raw HTTP response into requested domain type.
+        /// </summary>
+        /// <typeparam name="T">The type to return</typeparam>
+        /// <param name="response">The HttpResponseMessage to handle</param>
+        /// <returns></returns>
         public async Task<T> HandleResponse<T>(HttpResponseMessage response)
         {
             if (response.Content != null)

--- a/tests/Microsoft.Graph.Core.Test/Microsoft.Graph.Core.Test.csproj
+++ b/tests/Microsoft.Graph.Core.Test/Microsoft.Graph.Core.Test.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Requests\Middleware\Options\RetrytHandlerOptionTests.cs" />
     <Compile Include="Requests\Middleware\RedirectHandlerTests.cs" />
     <Compile Include="Requests\Middleware\RetryHandlerTests.cs" />
+    <Compile Include="Requests\ResponseHandlerTests.cs" />
     <Compile Include="Serialization\DurationConverterTests.cs" />
     <Compile Include="TestModels\AbstractEntityType.cs" />
     <Compile Include="TestModels\ClassWithJson.cs" />

--- a/tests/Microsoft.Graph.Core.Test/Requests/ResponseHandlerTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/ResponseHandlerTests.cs
@@ -1,0 +1,47 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Graph.Core.Test.Requests
+{
+    [TestClass]
+    public class ResponseHandlerTests
+    {
+        [TestMethod]
+        public async Task HandleUserResponse()
+        {
+            // Arrange
+            var responseHandler = new ResponseHandler(new Serializer());
+            var hrm = new HttpResponseMessage()
+            {
+                Content = new StringContent(@"{
+    ""id"": ""123"",
+    ""givenName"": ""Joe"",
+    ""surName"": ""Brown"",
+    ""@odata.type"":""test""
+}", Encoding.UTF8, "application/json")
+            };
+            hrm.Headers.Add("test", "value");
+
+            // Act
+            var user = await responseHandler.HandleResponse<User>(hrm);
+
+            //Assert
+            Assert.AreEqual("123", user.Id);
+            Assert.AreEqual("Joe", user.GivenName);
+            Assert.AreEqual("Brown", user.Surname);
+            Assert.AreEqual("OK", user.AdditionalData["statusCode"]);
+            var headers = (JObject)(user.AdditionalData["responseHeaders"]);
+            Assert.AreEqual("value", (string)headers["test"][0]);
+        }
+    }
+}


### PR DESCRIPTION
This PR allows using a native httpClient instance to get a HttpRequestMessage instance and then process it in a normal way to return a strongly typed object.

```csharp
var hrm = await httpClient.SendAsync(httpRequestMessage);
var user = await responseHandler.HandleResponse<User>(hrm);
```

