### PR TITLE
Updates AuthenticationHandlers SendRetryAsync to use per request provider.

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Graph
 
                 // Authenticate request using AuthenticationProvider
 
-                await AuthenticationProvider.AuthenticateRequestAsync(newRequest);
+                await authProvider.AuthenticateRequestAsync(newRequest);
                 httpResponseMessage = await base.SendAsync(newRequest, cancellationToken);
 
                 retryAttempt++;


### PR DESCRIPTION
<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Updates AuthenticationHandlers SendRetryAsync to use per request authentication provider when one is set.
