### PR TITLE
Make GraphClientFactory public

### DIFF
--- a/src/Microsoft.Graph.Core/GraphCloud.cs
+++ b/src/Microsoft.Graph.Core/GraphCloud.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// Selector for national cloud
+    /// </summary>
+    public enum GraphCloud
+    {
+        Global,
+        USGovernment,
+        China,
+        Germany
+    }
+}

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// GraphClientFactory class to create the HTTP client
     /// </summary>
-    internal static class GraphClientFactory
+    public static class GraphClientFactory
     {
 
 
@@ -40,7 +40,7 @@ namespace Microsoft.Graph
         private static readonly string _baseAddress = "https://graph.microsoft.com/";
 
         /// Microsoft Graph service nationa cloud endpoints
-        private static readonly Dictionary<string, string> cloudList = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> cloudList = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase)
             {
                 { Global_Cloud, "https://graph.microsoft.com" },
                 { USGOV_Cloud, "https://graph.microsoft.com" },

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -163,38 +163,5 @@ namespace Microsoft.Graph
 
             return pipeline;
         }
-
-
-
-        ///// <summary>
-        ///// Configure an instance of an <see cref="HttpClient"/>
-        ///// </summary>
-        ///// <param name="client">The <see cref="HttpClient"/> client instance need to be configured.</param>
-        ///// <param name="timeout">A <see cref="TimeSpan"/> value for the HTTP client timeout property.</param>
-        ///// <param name="baseAddress">A <see cref="Uri"/> value to set the HTTP client BaseAddress property.</param>
-        ///// <param name="cacheControlHeaderValue">A <see cref="CacheControlHeaderValue"/> value to set HTTP client DefaultRequestHeaders property.</param>
-        ///// <returns></returns>
-        //public static HttpClient Configure(HttpClient client, TimeSpan timeout, Uri baseAddress, CacheControlHeaderValue cacheControlHeaderValue)
-        //{
-        //    try
-        //    {
-        //        client.Timeout = timeout;
-        //    }
-        //    catch (InvalidOperationException exception)
-        //    {
-        //        throw new ServiceException(
-        //            new Error
-        //            {
-        //                Code = ErrorConstants.Codes.NotAllowed,
-        //                Message = ErrorConstants.Messages.OverallTimeoutCannotBeSet,
-        //            },
-        //            exception);
-        //    }
-
-        //    client.BaseAddress = baseAddress == null ? new Uri(_baseAddress + Version) : baseAddress;
-        //    client.DefaultRequestHeaders.CacheControl = cacheControlHeaderValue ?? new CacheControlHeaderValue { NoCache = true, NoStore = true };
-        //    return client;
-        //}
-
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -11,14 +11,11 @@ namespace Microsoft.Graph
     using System.Reflection;
     using System.Net.Http.Headers;
 
-
     /// <summary>
     /// GraphClientFactory class to create the HTTP client
     /// </summary>
     public static class GraphClientFactory
     {
-
-
         /// The key for the SDK version header.
         private static readonly string SdkVersionHeaderName = CoreConstants.Headers.SdkVersionHeaderName;
 
@@ -40,24 +37,15 @@ namespace Microsoft.Graph
         private static readonly string _baseAddress = "https://graph.microsoft.com/";
 
         /// Microsoft Graph service nationa cloud endpoints
-        private static readonly Dictionary<string, string> cloudList = new Dictionary<string, string> (StringComparer.OrdinalIgnoreCase)
+        private static readonly Dictionary<GraphCloud, string> cloudList = new Dictionary<GraphCloud, string> 
             {
-                { Global_Cloud, "https://graph.microsoft.com" },
-                { USGOV_Cloud, "https://graph.microsoft.com" },
-                { China_Cloud, "https://microsoftgraph.chinacloudapi.cn" },
-                { Germany_Cloud, "https://graph.microsoft.de" }
+                { GraphCloud.Global, "https://graph.microsoft.com" },
+                { GraphCloud.USGovernment, "https://graph.microsoft.com" },
+                { GraphCloud.China, "https://microsoftgraph.chinacloudapi.cn" },
+                { GraphCloud.Germany, "https://graph.microsoft.de" }
             };
 
         private static FeatureFlag featureFlags;
-
-        /// Global endpoint
-        public const string Global_Cloud = "Global";
-        /// US_GOV endpoint
-        public const string USGOV_Cloud = "US_GOV";
-        /// China endpoint
-        public const string China_Cloud = "China";
-        /// Germany endpoint
-        public const string Germany_Cloud = "Germany";
 
         /// <summary>
         /// Proxy to be used with created clients
@@ -87,7 +75,7 @@ namespace Microsoft.Graph
         /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for
         /// an outbound request message but last for an inbound response message.</param>
         /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
-        public static HttpClient Create(string version = "v1.0", string nationalCloud = Global_Cloud, IEnumerable<DelegatingHandler> handlers = null)
+        public static HttpClient Create(string version = "v1.0", GraphCloud nationalCloud = GraphCloud.Global, IEnumerable<DelegatingHandler> handlers = null)
         {
             HttpMessageHandler pipeline;
             if (handlers == null)
@@ -121,7 +109,7 @@ namespace Microsoft.Graph
             };
         }
 
-        private static Uri DetermineBaseAddress(string nationalCloud, string version)
+        private static Uri DetermineBaseAddress(GraphCloud nationalCloud, string version)
         {
             string cloud = "";
             if (!cloudList.TryGetValue(nationalCloud, out cloud))
@@ -130,7 +118,6 @@ namespace Microsoft.Graph
             }
             string cloudAddress = cloud + "/" + version;
             return new Uri(cloudAddress);
-
         }
 
         /// <summary>

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Graph
             };
 
             GraphClientFactory.DefaultHttpHandler = () => this.httpMessageHandler;
-            this.httpClient = GraphClientFactory.Create("v1.0", GraphClientFactory.Global_Cloud, handlers);
+            this.httpClient = GraphClientFactory.Create("v1.0", GraphCloud.Global, handlers);
             this.httpClient.SetFeatureFlags(FeatureFlag.RedirectHandler | FeatureFlag.RetryHandler | FeatureFlag.AuthHandler |
                 FeatureFlag.DefaultHttpProvider);
         }

--- a/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -110,7 +110,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreateClient_SelectedCloudAndVersion()
         {
-            using (HttpClient httpClient = GraphClientFactory.Create(version: "beta", nationalCloud: GraphClientFactory.Germany_Cloud))
+            using (HttpClient httpClient = GraphClientFactory.Create(version: "beta", nationalCloud: GraphCloud.Germany))
             {
                 Assert.IsNotNull(httpClient, "Create Http client failed.");
                 Uri clouldEndpoint = new Uri("https://graph.microsoft.de/beta");
@@ -122,15 +122,14 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreateClient_SelectedCloudWithExceptions()
         {
-            string nation = "Canada";
             try
             {
-                HttpClient httpClient = GraphClientFactory.Create(nationalCloud: nation);
+                HttpClient httpClient = GraphClientFactory.Create(nationalCloud: (GraphCloud)7);
             }
             catch (ArgumentException exception)
             {
                 Assert.IsInstanceOfType(exception, typeof(ArgumentException), "Eeception is not the right type");
-                Assert.AreEqual(exception.Message, String.Format("{0} is an unexpected national cloud.", nation));
+                Assert.AreEqual(exception.Message, String.Format("{0} is an unexpected national cloud.", 7));
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreateClient_SelectedCloud()
         {
-            using (HttpClient httpClient = GraphClientFactory.Create(version: "beta", nationalCloud: GraphClientFactory.Germany_Cloud))
+            using (HttpClient httpClient = GraphClientFactory.Create(version: "beta", nationalCloud: GraphCloud.Germany))
             {
                 Assert.NotNull(httpClient);
                 Uri clouldEndpoint = new Uri("https://graph.microsoft.de/beta");
@@ -123,15 +123,14 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreateClient_SelectedCloudWithExceptions()
         {
-            string nation = "Canada";
-            try
+             try
             {
-                HttpClient httpClient = GraphClientFactory.Create(nationalCloud: nation);
+                HttpClient httpClient = GraphClientFactory.Create(nationalCloud: (GraphCloud)7);
             }
             catch (ArgumentException exception)
             {
                 Assert.IsType(typeof(ArgumentException), exception);
-                Assert.Equal(exception.Message, String.Format("{0} is an unexpected national cloud.", nation));
+                Assert.Equal(exception.Message, String.Format("{0} is an unexpected national cloud.", 7));
             }
         }
 


### PR DESCRIPTION
This PR exposes the GraphClientFactory class so developers can use it to create HttpClient instances that are configured to call the Graph.

Also changed selection of national cloud to use an enum.