### PR TITLE
Patches for V1.14.0

### DIFF
--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -15,6 +15,7 @@
     <PackageReleaseNotes>
 March 2019 Release Summary (version 1.14.1)
 
+- Fixes #413 - Slow middleware handler requests.
 - Fixes #417 - Custom IHttpProvider uses IAuthenticationProvider set in the GraphServiceClient constructor.
     </PackageReleaseNotes>
     <PackageProjectUrl>https://developer.microsoft.com/graph</PackageProjectUrl>

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -61,11 +61,13 @@ namespace Microsoft.Graph
             this.httpMessageHandler = httpMessageHandler ?? new HttpClientHandler { AllowAutoRedirect = false };
             this.Serializer = serializer ?? new Serializer();
 
+            // Always ensure RedirectHandler is the last handler in your pipeline.
+            // The recommended DelegatingHandler order is : 1. AuthenticationHandler, 2. RetryHandler, 3.RedirectHandler.
             DelegatingHandler[] handlers = new DelegatingHandler[]
             {
-                new RedirectHandler(),
+                new AuthenticationHandler(null),
                 new RetryHandler(),
-                new AuthenticationHandler(null)
+                new RedirectHandler()
             };
 
             GraphClientFactory.DefaultHttpHandler = () => this.httpMessageHandler;

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
@@ -82,10 +82,10 @@ namespace Microsoft.Graph
 
                     // Set newRequestUri from response
                     newRequest.RequestUri = response.Headers.Location;
-                    
+
                     // Remove Auth if http request's scheme or host changes
-                    if (String.Compare(newRequest.RequestUri.Host, request.RequestUri.Host, StringComparison.OrdinalIgnoreCase) != 0 || 
-                        !newRequest.RequestUri.Scheme.Equals(request.RequestUri.Scheme))
+                    if (String.CompareOrdinal(newRequest.RequestUri.Host, request.RequestUri.Host) != 0 ||
+                        String.CompareOrdinal(newRequest.RequestUri.Scheme, request.RequestUri.Scheme) != 0)
                     {
                         newRequest.Headers.Authorization = null;
                     }

--- a/tests/Microsoft.Graph.Core.Test/Microsoft.Graph.Core.Test.csproj
+++ b/tests/Microsoft.Graph.Core.Test/Microsoft.Graph.Core.Test.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Helpers\ExtractSelectHelperTest.cs" />
     <Compile Include="Helpers\StringHelperTests.cs" />
     <Compile Include="Helpers\UrlHelperTests.cs" />
+    <Compile Include="Mocks\MockCustomHttpProvider.cs" />
     <Compile Include="Mocks\MockProgress.cs" />
     <Compile Include="Mocks\MockRedirectHandler.cs" />
     <Compile Include="Requests\AsyncMonitorTests.cs" />

--- a/tests/Microsoft.Graph.Core.Test/Mocks/MockCustomHttpProvider.cs
+++ b/tests/Microsoft.Graph.Core.Test/Mocks/MockCustomHttpProvider.cs
@@ -1,0 +1,65 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.Core.Test.Mocks
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    public class MockCustomHttpProvider : IHttpProvider
+    {
+        private MockSerializer serializer = new MockSerializer();
+        internal HttpClient httpClient;
+        public MockCustomHttpProvider(HttpMessageHandler httpMessageHandler)
+        {
+            httpClient = new HttpClient(httpMessageHandler);
+        }
+        public ISerializer Serializer => serializer.Object;
+
+        public TimeSpan OverallTimeout
+        {
+            get
+            {
+                return this.httpClient.Timeout;
+            }
+
+            set
+            {
+                try
+                {
+                    this.httpClient.Timeout = value;
+                }
+                catch (InvalidOperationException exception)
+                {
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = ErrorConstants.Codes.NotAllowed,
+                            Message = ErrorConstants.Messages.OverallTimeoutCannotBeSet,
+                        },
+                        exception);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (this.httpClient != null)
+            {
+                this.httpClient.Dispose();
+            }
+        }
+
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            return this.SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        {
+            return await this.httpClient.SendAsync(request, completionOption, cancellationToken);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/BaseRequestTests.cs
@@ -373,6 +373,27 @@ namespace Microsoft.Graph.Core.Test.Requests
         }
 
         [TestMethod]
+        public async Task SendAsync_WithCustomHttpProvider()
+        {
+            using (var httpResponseMessage = new HttpResponseMessage())
+            using (TestHttpMessageHandler testHttpMessageHandler = new TestHttpMessageHandler())
+            {
+                string requestUrl = "https://localhost/";
+                testHttpMessageHandler.AddResponseMapping(requestUrl, httpResponseMessage);
+                MockCustomHttpProvider customHttpProvider = new MockCustomHttpProvider(testHttpMessageHandler);
+
+                BaseClient client = new BaseClient(requestUrl, authenticationProvider.Object, customHttpProvider);
+                BaseRequest baseRequest = new BaseRequest(requestUrl, client);
+
+                HttpResponseMessage returnedResponse = await baseRequest.SendRequestAsync("string", CancellationToken.None);
+
+                Assert.AreEqual(httpResponseMessage, returnedResponse, "Unexpected response message returned.");
+                Assert.IsNotNull(returnedResponse.RequestMessage.Headers, "Headers cannot be null.");
+                Assert.AreEqual(returnedResponse.RequestMessage.Headers.Authorization.Parameter, "Default-Token", "Unexpected authorization header set.");
+            }
+        }
+
+        [TestMethod]
         public void BuildQueryString_NullQueryOptions()
         {
             var baseRequest = new BaseRequest("https://localhost", this.baseClient);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockCustomHttpProvider.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/MockCustomHttpProvider.cs
@@ -1,0 +1,65 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
+{
+    using System;
+    using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
+    public class MockCustomHttpProvider : IHttpProvider
+    {
+        private MockSerializer serializer = new MockSerializer();
+        internal HttpClient httpClient;
+        public MockCustomHttpProvider(HttpMessageHandler httpMessageHandler)
+        {
+            httpClient = new HttpClient(httpMessageHandler);
+        }
+        public ISerializer Serializer => serializer.Object;
+
+        public TimeSpan OverallTimeout
+        {
+            get
+            {
+                return this.httpClient.Timeout;
+            }
+
+            set
+            {
+                try
+                {
+                    this.httpClient.Timeout = value;
+                }
+                catch (InvalidOperationException exception)
+                {
+                    throw new ServiceException(
+                        new Error
+                        {
+                            Code = ErrorConstants.Codes.NotAllowed,
+                            Message = ErrorConstants.Messages.OverallTimeoutCannotBeSet,
+                        },
+                        exception);
+                }
+            }
+        }
+
+        public void Dispose()
+        {
+            if (this.httpClient != null)
+            {
+                this.httpClient.Dispose();
+            }
+        }
+
+        public Task<HttpResponseMessage> SendAsync(HttpRequestMessage request)
+        {
+            return this.SendAsync(request, HttpCompletionOption.ResponseContentRead, CancellationToken.None);
+        }
+
+        public async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, HttpCompletionOption completionOption, CancellationToken cancellationToken)
+        {
+            return await this.httpClient.SendAsync(request, completionOption, cancellationToken);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -2,6 +2,7 @@
 //  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
 // ------------------------------------------------------------------------------
 
+using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
 using Microsoft.Graph.DotnetCore.Core.Test.TestModels;
 using Moq;
 using System;
@@ -313,6 +314,27 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 {
                     Assert.Equal(await httpResponseMessage.Content.ReadAsStreamAsync(), returnedResponseStream);
                 }
+            }
+        }
+
+        [Fact]
+        public async Task SendAsync_WithCustomHttpProvider()
+        {
+            using (var httpResponseMessage = new HttpResponseMessage())
+            using (TestHttpMessageHandler testHttpMessageHandler = new TestHttpMessageHandler())
+            {
+                string requestUrl = "https://localhost/";
+                testHttpMessageHandler.AddResponseMapping(requestUrl, httpResponseMessage);
+                MockCustomHttpProvider customHttpProvider = new MockCustomHttpProvider(testHttpMessageHandler);
+
+                BaseClient client = new BaseClient(requestUrl, authenticationProvider.Object, customHttpProvider);
+                BaseRequest baseRequest = new BaseRequest(requestUrl, client);
+
+                HttpResponseMessage returnedResponse = await baseRequest.SendRequestAsync("string", CancellationToken.None);
+
+                Assert.Equal(httpResponseMessage, returnedResponse);
+                Assert.NotNull(returnedResponse.RequestMessage.Headers);
+                Assert.Equal(returnedResponse.RequestMessage.Headers.Authorization.Parameter, "Default-Token");
             }
         }
 


### PR DESCRIPTION
This PR fixes the following issues reported in 1.14.0 release:

- Issue #413 - Slow concurrent requests when using our pipeline. This PR updates the middleware handlers order to always ensure `RedirectHandler` is the last handler in the pipeline. This significantly reduces the time it takes to process concurrent calls.
- Issue #417 - AuthorizationProvider is ignored when using a custom IHttpProvider. This PR ensures `AuthenticationProvider.AuthenticateRequestAsync` is always called in `BaseRequest` when using a custom `IHttpprovider`. It also adds a unit test for custom IHttpProvider.