### PR TITLE
Page iterator

### DIFF
--- a/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph.Core/Tasks/PageIterator.cs
@@ -12,16 +12,16 @@ Spec
 namespace Microsoft.Graph
 {
     /// <summary>
-    /// Use PageIterator&lt;T&gt; to automatically page through result sets across multiple calls 
+    /// Use PageIterator&lt;TEntity&gt; to automatically page through result sets across multiple calls 
     /// and process each item in the result set.
     /// </summary>
-    /// <typeparam name="T">The common entity type returned in the result set.</typeparam>
-    public class PageIterator<T> where T : Entity
+    /// <typeparam name="TEntity">The Microsoft Graph entity type returned in the result set.</typeparam>
+    public class PageIterator<TEntity>
     {
-        private GraphServiceClient client;
-        private ICollectionPage<T> currentPage;
-        private Queue<T> pageItemQueue;
-        private Func<T, bool> processPageItemCallback;
+        private IBaseClient client;
+        private ICollectionPage<TEntity> currentPage;
+        private Queue<TEntity> pageItemQueue;
+        private Func<TEntity, bool> processPageItemCallback;
         
         /// <summary>
         /// The @odata.deltaLink returned from a delta query.
@@ -41,9 +41,9 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="client">The GraphServiceClient object used to create the NextPageRequest for a delta query.</param>
         /// <param name="page">A generated implementation of ICollectionPage.</param>
-        /// <param name="callback">A Func delegate that processes type T in the result set and should return false if the iterator should cancel processing.</param>
-        /// <returns>A PageIterator&lt;T&gt; that will process additional result pages based on the rules specified in Func&lt;T,bool&gt; processPageItems</returns>
-        public static PageIterator<T> CreatePageIterator(GraphServiceClient client, ICollectionPage<T> page, Func<T,bool> callback)
+        /// <param name="callback">A Func delegate that processes type TEntity in the result set and should return false if the iterator should cancel processing.</param>
+        /// <returns>A PageIterator&lt;TEntity&gt; that will process additional result pages based on the rules specified in Func&lt;TEntity,bool&gt; processPageItems</returns>
+        public static PageIterator<TEntity> CreatePageIterator(IBaseClient client, ICollectionPage<TEntity> page, Func<TEntity,bool> callback)
         {
             if (page == null)
                 throw new ArgumentNullException("page");
@@ -51,11 +51,11 @@ namespace Microsoft.Graph
             if (callback == null)
                 throw new ArgumentNullException("processPageItems");
 
-            return new PageIterator<T>()
+            return new PageIterator<TEntity>()
             {
                 client = client,
                 currentPage = page,
-                pageItemQueue = new Queue<T>(page),
+                pageItemQueue = new Queue<TEntity>(page),
                 processPageItemCallback = callback,
                 State = PagingState.NotStarted
             };
@@ -98,7 +98,7 @@ namespace Microsoft.Graph
         {
             State = PagingState.InterpageIteration;
 
-            // We need access to the NextPageRequest to call and get the next page. ICollectionPage<T> doesn't define NextPageRequest.
+            // We need access to the NextPageRequest to call and get the next page. ICollectionPage<TEntity> doesn't define NextPageRequest.
             // We are making this dynamic so we can access NextPageRequest.
             dynamic page = this.currentPage;
 
@@ -109,13 +109,13 @@ namespace Microsoft.Graph
 
             if (this.currentPage.Count > 0)
             {
-                this.pageItemQueue = new Queue<T>(this.currentPage);
+                this.pageItemQueue = new Queue<TEntity>(this.currentPage);
                 await IterateAsync(token);
             }
         }
 
         /// <summary>
-        /// Fetches page collections and iterates through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
+        /// Fetches page collections and iterates through each page of items and processes it according to the Func&lt;TEntity, bool&gt; set in <see cref="CreatePageIterator"/>. 
         /// </summary>
         /// <returns>The task object that represents the results of this asynchronous operation.</returns>
         /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage that does not implement NextPageRequest
@@ -128,7 +128,7 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Fetches page collections and iterates through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
+        /// Fetches page collections and iterates through each page of items and processes it according to the Func&lt;TEntity, bool&gt; set in <see cref="CreatePageIterator"/>. 
         /// </summary>
         /// <param name="token">The CancellationToken used to stop iterating calls for more pages.</param>
         /// <returns>The task object that represents the results of this asynchronous operation.</returns>
@@ -180,7 +180,7 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Resumes iterating through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
+        /// Resumes iterating through each page of items and processes it according to the Func&lt;TEntity, bool&gt; set in <see cref="CreatePageIterator"/>. 
         /// </summary>
         /// <returns>The task object that represents the results of this asynchronous operation.</returns>
         /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage that does not implement NextPageRequest
@@ -191,7 +191,7 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Resumes iterating through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
+        /// Resumes iterating through each page of items and processes it according to the Func&lt;TEntity, bool&gt; set in <see cref="CreatePageIterator"/>. 
         /// </summary>
         /// <param name="token">The CancellationToken used to stop iterating calls for more pages.</param>
         /// <returns>The task object that represents the results of this asynchronous operation.</returns>

--- a/src/Microsoft.Graph/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph/Tasks/PageIterator.cs
@@ -1,0 +1,123 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+/**
+
+Spec
+    https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/tasks/PageIteratorTask.md
+**/
+
+namespace Microsoft.Graph
+{
+    /// <summary>
+    /// Use PageIterator&lt;T&gt; to automatically page through result sets across multiple calls 
+    /// and process each item in the result set.
+    /// </summary>
+    /// <typeparam name="T">The common entity type returned in the result set.</typeparam>
+    public class PageIterator<T> where T : Entity
+    {
+        private ICollectionPage<T> initialPage;
+        private Func<T, bool> processPageItem;
+
+        public string Deltalink { get; private set; }
+        public string Nextlink { get; private set; }
+
+        /// <summary>
+        /// Creates the PageIterator with the results of an initial paged request. 
+        /// </summary>
+        /// <param name="page"></param>
+        /// <param name="processPageItems">A Func delegate that processes type T in the result set and should return false if the iterator should cancel processing.</param>
+        /// <returns>A PageIterator&lt;T&gt; that will process additional result pages based on the rules specified in Func&lt;T,bool&gt; processPageItems</returns>
+        public static PageIterator<T> CreatePageIterator(ICollectionPage<T> page, Func<T,bool> processPageItems)
+        {
+            if (page == null)
+                throw new ArgumentNullException("page");
+
+            if (processPageItems == null)
+                throw new ArgumentNullException("processPageItems");
+
+            return new PageIterator<T>()
+            {
+                initialPage = page,
+                processPageItem = processPageItems
+            };
+        }
+
+        /// <summary>
+        /// Fetches page collections and iterates through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
+        /// </summary>
+        /// <returns>The task object that represents the results of this asynchronous operation.</returns>
+        /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage does not implement NextPageRequest.
+        /// is provided to the PageIterator</exception>
+        public async Task IterateAsync()
+        {
+            await IterateAsync(new CancellationToken());
+        }
+
+        /// <summary>
+        /// Fetches page collections and iterates through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
+        /// </summary>
+        /// <param name="token">The CancellationToken used to stop iterating calls for more pages.</param>
+        /// <returns>The task object that represents the results of this asynchronous operation.</returns>
+        /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage does not implement NextPageRequest.
+        /// is provided to the PageIterator</exception>
+        public async Task IterateAsync(CancellationToken token)
+        {
+            // TODO: Handle DeltaLink. We should probably return it as a string if the NextPageRequest 
+            // returns @odata.deltalink. Q: should we have the customer specify whether they are iterating
+            // based on a delta query, or do we always check for the value and return it when it is present?
+
+            // We need access to the NextPageRequest to call and get the next page. ICollectionPage<T> doesn't define NextPageRequest.
+            // We are making this dynamic so we can access NextPageRequest.
+            dynamic page = initialPage;
+
+            bool shouldFetchMorePages = true; // Set false if no more pages to fetch or if processPageItem() returns false
+
+            do
+            {
+                // Process each item in a page.
+                foreach (T item in page) // TODO: remove items from the current page collection as they are processed so that we resume from the same spot.
+                {
+                    bool shouldContinue = processPageItem(item);
+
+                    // Cancel processing of items in the page and stop requesting more pages.
+                    if (!shouldContinue)
+                    {
+                        shouldFetchMorePages = false;
+                        break;
+                    }
+                }
+
+                // Fetch the next page of results. RuntimeBinderException expection can be thrown if page is a base CollectionPage object.
+                if (page.NextPageRequest != null && shouldFetchMorePages && !token.IsCancellationRequested)
+                {
+                    page = await page.NextPageRequest.GetAsync().ConfigureAwait(false);
+                }
+                else
+                {
+                    shouldFetchMorePages = false;
+                }
+            } while (shouldFetchMorePages);
+        }
+
+        // TODO: Add paging completeness state.
+        // TODO: if page.NextPageRequest is null, then we need to check for a deltalink and save that. 
+
+        public async Task ResumeAsync()
+        {
+            await ResumeAsync(new CancellationToken());
+        }
+
+        public async Task ResumeAsync(CancellationToken token)
+        {
+            // TODO: when resuming, we first attempt to go through the current collection page. Next, we try to 
+            // get the NextPageRequest. Then, when page.NextPageRequest is exhausted, we check whether there is 
+            // deltalink. With DeltaLink set, we set state to complete. If ResumeAsnc is called with deltalink set,
+            // we set page.InitializeNextPage with deltaLInk, delete that deltalink property, set state to iterating,
+            // and call page.NextPageRequest(), looping until we are back here again.
+            // Or do I just set DeltaLink and let customer submit a CollectionPage with Deltalink set on it.
+            await IterateAsync(token);
+        }
+    }
+}

--- a/src/Microsoft.Graph/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph/Tasks/PageIterator.cs
@@ -18,22 +18,32 @@ namespace Microsoft.Graph
     /// <typeparam name="T">The common entity type returned in the result set.</typeparam>
     public class PageIterator<T> where T : Entity
     {
+        private GraphServiceClient client;
         private ICollectionPage<T> currentPage;
         private Queue<T> pageItemQueue;
         private Func<T, bool> processPageItemCallback;
-
-        // Allow dev to restart paging after PageIterator<T> with these properties and the InitializeNextPage method on descendents of ICollectionPage<T>.
+        
+        /// <summary>
+        /// The @odata.deltaLink returned from a delta query.
+        /// </summary>
         public string Deltalink { get; private set; }
+        /// <summary>
+        /// The @odata.nextLink returned in a paged result.
+        /// </summary>
         public string Nextlink { get; private set; }
+        /// <summary>
+        /// The PageIterator state.
+        /// </summary>
         public PagingState State { get; set; }
 
         /// <summary>
         /// Creates the PageIterator with the results of an initial paged request. 
         /// </summary>
-        /// <param name="page"></param>
+        /// <param name="client">The GraphServiceClient object used to create the NextPageRequest for a delta query.</param>
+        /// <param name="page">A generated implementation of ICollectionPage.</param>
         /// <param name="callback">A Func delegate that processes type T in the result set and should return false if the iterator should cancel processing.</param>
         /// <returns>A PageIterator&lt;T&gt; that will process additional result pages based on the rules specified in Func&lt;T,bool&gt; processPageItems</returns>
-        public static PageIterator<T> CreatePageIterator(ICollectionPage<T> page, Func<T,bool> callback)
+        public static PageIterator<T> CreatePageIterator(GraphServiceClient client, ICollectionPage<T> page, Func<T,bool> callback)
         {
             if (page == null)
                 throw new ArgumentNullException("page");
@@ -43,19 +53,24 @@ namespace Microsoft.Graph
 
             return new PageIterator<T>()
             {
+                client = client,
                 currentPage = page,
                 pageItemQueue = new Queue<T>(page),
-                State = PagingState.NotStarted,
-                processPageItemCallback = callback
+                processPageItemCallback = callback,
+                State = PagingState.NotStarted
             };
         }
 
         /// <summary>
-        /// Iterate across the content of a a single results page.
+        /// Iterate across the content of a a single results page with the callback.
         /// </summary>
-        /// <returns>A boolean that indicates whether to stop iterating.</returns>
+        /// <returns>A boolean value that indicates whether the callback cancelled 
+        /// iterating across the page results. A value of false indicates that
+        /// the iterator should stop iterating.</returns>
         private bool IntrapageIterate()
         {
+            State = PagingState.IntrapageIteration;
+
             bool shouldContinue = true;
 
             while (pageItemQueue.Count != 0 && shouldContinue)
@@ -72,26 +87,41 @@ namespace Microsoft.Graph
             return shouldContinue;
         }
 
+        /// <summary>
+        /// Call the next page request when there is another page of data.
+        /// </summary>
+        /// <param name="token"></param>
+        /// <returns>The task object that represents the results of this asynchronous operation.</returns>
+        /// <exception cref="Microsoft.Graph.ServiceException">Thrown when the service encounters an error with
+        /// a request.</exception>
         private async Task InterpageIterateAsync(CancellationToken token)
         {
-            // Now iterate over the result pages.
+            State = PagingState.InterpageIteration;
+
             // We need access to the NextPageRequest to call and get the next page. ICollectionPage<T> doesn't define NextPageRequest.
             // We are making this dynamic so we can access NextPageRequest.
             dynamic page = this.currentPage;
 
+            if (page.NextPageRequest == null)
+                return;
+
             this.currentPage = await page.NextPageRequest.GetAsync(token).ConfigureAwait(false);
-            this.pageItemQueue = new Queue<T>(this.currentPage);
 
-
-            await IterateAsync(token);
+            if (this.currentPage.Count > 0)
+            {
+                this.pageItemQueue = new Queue<T>(this.currentPage);
+                await IterateAsync(token);
+            }
         }
-        
+
         /// <summary>
         /// Fetches page collections and iterates through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
         /// </summary>
         /// <returns>The task object that represents the results of this asynchronous operation.</returns>
-        /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage does not implement NextPageRequest.
+        /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage that does not implement NextPageRequest
         /// is provided to the PageIterator</exception>
+        /// <exception cref="Microsoft.Graph.ServiceException">Thrown when the service encounters an error with
+        /// a request.</exception>
         public async Task IterateAsync()
         {
             await IterateAsync(new CancellationToken());
@@ -102,82 +132,107 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="token">The CancellationToken used to stop iterating calls for more pages.</param>
         /// <returns>The task object that represents the results of this asynchronous operation.</returns>
-        /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage does not implement NextPageRequest.
+        /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage that does not implement NextPageRequest
         /// is provided to the PageIterator</exception>
         /// <exception cref="Microsoft.Graph.ServiceException">Thrown when the service encounters an error with
         /// a request.</exception>
         public async Task IterateAsync(CancellationToken token)
         {
-            // TODO: Handle DeltaLink. We should probably return it as a string if the NextPageRequest 
-            // returns @odata.deltalink. Q: should we have the customer specify whether they are iterating
-            // based on a delta query, or do we always check for the value and return it when it is present?
-
-
             // Iterate over the contents of the current page with the callback.
-            bool advance = this.IntrapageIterate();
-            if (advance)
+            bool requestMorePages = IntrapageIterate();
+
+            // Request more pages if they are available.
+            if (requestMorePages && !token.IsCancellationRequested)
             {
+                dynamic page = this.currentPage;
+                
                 // Capture the nextLink and deltaLink in case we need to restart iteration. 
-                // Optimize for nextLink, no link, and then deltalink.
-                object deltalink, nextlink;
+                object nextlink;
+                currentPage.AdditionalData.TryGetValue("@odata.nextLink", out nextlink);
+                Nextlink = nextlink as string;
 
-                if (currentPage.AdditionalData != null && currentPage.AdditionalData.TryGetValue("@odata.nextlink", out nextlink))
+                object deltalink;
+                currentPage.AdditionalData.TryGetValue("@odata.deltaLink", out deltalink);
+                Deltalink = deltalink as string;
+
+                if (page.NextPageRequest != null)
                 {
-                    this.Nextlink = nextlink.ToString();
-                    // TODO: get the nextlink and continue inter page iteration.
-
                     await InterpageIterateAsync(token);
-
                 }
-                else if (currentPage.AdditionalData != null && currentPage.AdditionalData.TryGetValue("@odata.deltalink", out deltalink))
+                else if (deltalink != null)
                 {
-                    this.Deltalink = deltalink.ToString();
-                    // TODO: InitializeNextPageRequest with the deltalink and stop iterating.
-                    // Customer determines when to resume iterating.
-                    advance = false;
-                    this.State = PagingState.Delta;
+                    page.InitializeNextPageRequest(this.client, Deltalink);
+                    this.currentPage = page;
+
+                    State = PagingState.Delta;
                 }
                 else
                 {
                     // Do nothing since there is nothing more to iterate.
-                    this.State = PagingState.Complete;
+                    State = PagingState.Complete;
                 }
             }
             else
             {
                 // intrapage iteration was cancelled by the callback. The iterator is in a resumeable state.
-                this.State = PagingState.Paused;
+                State = PagingState.Paused;
             }
         }
 
-        // TODO: Add paging completeness state.
-        // TODO: if page.NextPageRequest is null, then we need to check for a deltalink and save that. 
-
+        /// <summary>
+        /// Resumes iterating through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
+        /// </summary>
+        /// <returns>The task object that represents the results of this asynchronous operation.</returns>
+        /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage that does not implement NextPageRequest
+        /// is provided to the PageIterator</exception>
         public async Task ResumeAsync()
         {
             await ResumeAsync(new CancellationToken());
         }
 
+        /// <summary>
+        /// Resumes iterating through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
+        /// </summary>
+        /// <param name="token">The CancellationToken used to stop iterating calls for more pages.</param>
+        /// <returns>The task object that represents the results of this asynchronous operation.</returns>
+        /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage that does not implement NextPageRequest
+        /// is provided to the PageIterator</exception>
+        /// <exception cref="Microsoft.Graph.ServiceException">Thrown when the service encounters an error with
+        /// a request.</exception>
         public async Task ResumeAsync(CancellationToken token)
         {
-            // TODO: when resuming, we first attempt to go through the current collection page. Next, we try to 
-            // get the NextPageRequest. Then, when page.NextPageRequest is exhausted, we check whether there is 
-            // deltalink. With DeltaLink set, we set state to complete. If ResumeAsnc is called with deltalink set,
-            // we set page.InitializeNextPage with deltaLInk, delete that deltalink property, set state to iterating,
-            // and call page.NextPageRequest(), looping until we are back here again.
-            // Or do I just set DeltaLink and let customer submit a CollectionPage with Deltalink set on it.
             await IterateAsync(token);
         }
     }
 
+    /// <summary>
+    /// Specifies the state of the PageIterator.
+    /// </summary>
     public enum PagingState
     {
+        /// <summary>
+        /// The iterator has neither started iterating thorugh the initial page nor request more pages.
+        /// </summary>
         NotStarted,
+        /// <summary>
+        /// The callback returned false or a cancellation token was set. The iterator is resumeable.
+        /// </summary>
         Paused,
+        /// <summary>
+        /// Iterating across the contents of page.
+        /// </summary>
         IntrapageIteration,
+        /// <summary>
+        /// Iterating across paged requests.
+        /// </summary>
         InterpageIteration,
+        /// <summary>
+        /// A deltaToken was returned. The iterator is resumeable.
+        /// </summary>
         Delta,
+        /// <summary>
+        /// Reached the end of a non-deltaLink paged result set.
+        /// </summary>
         Complete
     }
-
 }

--- a/src/Microsoft.Graph/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph/Tasks/PageIterator.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -17,33 +18,74 @@ namespace Microsoft.Graph
     /// <typeparam name="T">The common entity type returned in the result set.</typeparam>
     public class PageIterator<T> where T : Entity
     {
-        private ICollectionPage<T> initialPage;
-        private Func<T, bool> processPageItem;
+        private ICollectionPage<T> currentPage;
+        private Queue<T> pageItemQueue;
+        private Func<T, bool> processPageItemCallback;
 
+        // Allow dev to restart paging after PageIterator<T> with these properties and the InitializeNextPage method on descendents of ICollectionPage<T>.
         public string Deltalink { get; private set; }
         public string Nextlink { get; private set; }
+        public PagingState State { get; set; }
 
         /// <summary>
         /// Creates the PageIterator with the results of an initial paged request. 
         /// </summary>
         /// <param name="page"></param>
-        /// <param name="processPageItems">A Func delegate that processes type T in the result set and should return false if the iterator should cancel processing.</param>
+        /// <param name="callback">A Func delegate that processes type T in the result set and should return false if the iterator should cancel processing.</param>
         /// <returns>A PageIterator&lt;T&gt; that will process additional result pages based on the rules specified in Func&lt;T,bool&gt; processPageItems</returns>
-        public static PageIterator<T> CreatePageIterator(ICollectionPage<T> page, Func<T,bool> processPageItems)
+        public static PageIterator<T> CreatePageIterator(ICollectionPage<T> page, Func<T,bool> callback)
         {
             if (page == null)
                 throw new ArgumentNullException("page");
 
-            if (processPageItems == null)
+            if (callback == null)
                 throw new ArgumentNullException("processPageItems");
 
             return new PageIterator<T>()
             {
-                initialPage = page,
-                processPageItem = processPageItems
+                currentPage = page,
+                pageItemQueue = new Queue<T>(page),
+                State = PagingState.NotStarted,
+                processPageItemCallback = callback
             };
         }
 
+        /// <summary>
+        /// Iterate across the content of a a single results page.
+        /// </summary>
+        /// <returns>A boolean that indicates whether to stop iterating.</returns>
+        private bool IntrapageIterate()
+        {
+            bool shouldContinue = true;
+
+            while (pageItemQueue.Count != 0 && shouldContinue)
+            {
+                shouldContinue = processPageItemCallback(pageItemQueue.Dequeue());
+
+                // Cancel processing of items in the page and stop requesting more pages.
+                if (!shouldContinue)
+                {
+                    break;
+                }
+            }
+
+            return shouldContinue;
+        }
+
+        private async Task InterpageIterateAsync(CancellationToken token)
+        {
+            // Now iterate over the result pages.
+            // We need access to the NextPageRequest to call and get the next page. ICollectionPage<T> doesn't define NextPageRequest.
+            // We are making this dynamic so we can access NextPageRequest.
+            dynamic page = this.currentPage;
+
+            this.currentPage = await page.NextPageRequest.GetAsync(token).ConfigureAwait(false);
+            this.pageItemQueue = new Queue<T>(this.currentPage);
+
+
+            await IterateAsync(token);
+        }
+        
         /// <summary>
         /// Fetches page collections and iterates through each page of items and processes it according to the Func&lt;T, bool&gt; set in <see cref="CreatePageIterator"/>. 
         /// </summary>
@@ -62,43 +104,50 @@ namespace Microsoft.Graph
         /// <returns>The task object that represents the results of this asynchronous operation.</returns>
         /// <exception cref="Microsoft.CSharp.RuntimeBinder.RuntimeBinderException">Thrown when a base CollectionPage does not implement NextPageRequest.
         /// is provided to the PageIterator</exception>
+        /// <exception cref="Microsoft.Graph.ServiceException">Thrown when the service encounters an error with
+        /// a request.</exception>
         public async Task IterateAsync(CancellationToken token)
         {
             // TODO: Handle DeltaLink. We should probably return it as a string if the NextPageRequest 
             // returns @odata.deltalink. Q: should we have the customer specify whether they are iterating
             // based on a delta query, or do we always check for the value and return it when it is present?
 
-            // We need access to the NextPageRequest to call and get the next page. ICollectionPage<T> doesn't define NextPageRequest.
-            // We are making this dynamic so we can access NextPageRequest.
-            dynamic page = initialPage;
 
-            bool shouldFetchMorePages = true; // Set false if no more pages to fetch or if processPageItem() returns false
-
-            do
+            // Iterate over the contents of the current page with the callback.
+            bool advance = this.IntrapageIterate();
+            if (advance)
             {
-                // Process each item in a page.
-                foreach (T item in page) // TODO: remove items from the current page collection as they are processed so that we resume from the same spot.
-                {
-                    bool shouldContinue = processPageItem(item);
+                // Capture the nextLink and deltaLink in case we need to restart iteration. 
+                // Optimize for nextLink, no link, and then deltalink.
+                object deltalink, nextlink;
 
-                    // Cancel processing of items in the page and stop requesting more pages.
-                    if (!shouldContinue)
-                    {
-                        shouldFetchMorePages = false;
-                        break;
-                    }
+                if (currentPage.AdditionalData != null && currentPage.AdditionalData.TryGetValue("@odata.nextlink", out nextlink))
+                {
+                    this.Nextlink = nextlink.ToString();
+                    // TODO: get the nextlink and continue inter page iteration.
+
+                    await InterpageIterateAsync(token);
+
                 }
-
-                // Fetch the next page of results. RuntimeBinderException expection can be thrown if page is a base CollectionPage object.
-                if (page.NextPageRequest != null && shouldFetchMorePages && !token.IsCancellationRequested)
+                else if (currentPage.AdditionalData != null && currentPage.AdditionalData.TryGetValue("@odata.deltalink", out deltalink))
                 {
-                    page = await page.NextPageRequest.GetAsync().ConfigureAwait(false);
+                    this.Deltalink = deltalink.ToString();
+                    // TODO: InitializeNextPageRequest with the deltalink and stop iterating.
+                    // Customer determines when to resume iterating.
+                    advance = false;
+                    this.State = PagingState.Delta;
                 }
                 else
                 {
-                    shouldFetchMorePages = false;
+                    // Do nothing since there is nothing more to iterate.
+                    this.State = PagingState.Complete;
                 }
-            } while (shouldFetchMorePages);
+            }
+            else
+            {
+                // intrapage iteration was cancelled by the callback. The iterator is in a resumeable state.
+                this.State = PagingState.Paused;
+            }
         }
 
         // TODO: Add paging completeness state.
@@ -120,4 +169,15 @@ namespace Microsoft.Graph
             await IterateAsync(token);
         }
     }
+
+    public enum PagingState
+    {
+        NotStarted,
+        Paused,
+        IntrapageIteration,
+        InterpageIteration,
+        Delta,
+        Complete
+    }
+
 }

--- a/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockUserEventsCollectionPage.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockUserEventsCollectionPage.cs
@@ -6,8 +6,15 @@ namespace Microsoft.Graph.DotnetCore.Test.Mocks
     public class MockUserEventsCollectionPage : CollectionPage<Event>, IUserEventsCollectionPage
     {
 
-        public MockUserEventsCollectionPage(IList<Event> currentPage, MockUserEventsCollectionRequest nextPageRequest) : base(currentPage)
+        public MockUserEventsCollectionPage(IList<Event> currentPage, MockUserEventsCollectionRequest nextPageRequest, string linkType = "") : base(currentPage)
         {
+            this.AdditionalData = new Dictionary<string, object>();
+
+            if (linkType == "nextlink")
+                AdditionalData.Add("@odata.nextlink", "testNextlink");
+            else if (linkType == "deltalink")
+                AdditionalData.Add("@odata.deltalink", "testDeltalink");
+
             NextPageRequest = nextPageRequest;
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockUserEventsCollectionPage.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockUserEventsCollectionPage.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Microsoft.Graph.DotnetCore.Test.Mocks
+{
+    public class MockUserEventsCollectionPage : CollectionPage<Event>, IUserEventsCollectionPage
+    {
+
+        public MockUserEventsCollectionPage(IList<Event> currentPage, MockUserEventsCollectionRequest nextPageRequest) : base(currentPage)
+        {
+            NextPageRequest = nextPageRequest;
+        }
+
+        public IUserEventsCollectionRequest NextPageRequest { get; private set; }
+
+        public void InitializeNextPageRequest(IBaseClient client, string nextPageLinkString)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockUserEventsCollectionRequest.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockUserEventsCollectionRequest.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Graph.DotnetCore.Test.Mocks
+{
+    public class MockUserEventsCollectionRequest : IUserEventsCollectionRequest
+    {
+        IUserEventsCollectionPage NextPage { get; }
+
+        public MockUserEventsCollectionRequest(
+            IUserEventsCollectionPage nextPage)
+        {
+            NextPage = nextPage;
+        }
+
+        public Task<IUserEventsCollectionPage> GetAsync()
+        {
+            return Task.FromResult<IUserEventsCollectionPage>(NextPage);
+        }
+
+        #region Not impl
+
+        public string ContentType { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public IList<HeaderOption> Headers => throw new NotImplementedException();
+
+        public IBaseClient Client => throw new NotImplementedException();
+
+        public string Method => throw new NotImplementedException();
+
+        public string RequestUrl => throw new NotImplementedException();
+
+        public IList<QueryOption> QueryOptions => throw new NotImplementedException();
+
+        public IDictionary<string, IMiddlewareOption> MiddlewareOptions => throw new NotImplementedException();
+
+
+
+        public Task<Event> AddAsync(Event eventsEvent)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<Event> AddAsync(Event eventsEvent, CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IUserEventsCollectionRequest Expand(string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IUserEventsCollectionRequest Expand(Expression<Func<Event, object>> expandExpression)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IUserEventsCollectionRequest Filter(string value)
+        {
+            throw new NotImplementedException();
+        }
+
+
+        public Task<IUserEventsCollectionPage> GetAsync(CancellationToken cancellationToken)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IUserEventsCollectionRequest OrderBy(string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IUserEventsCollectionRequest Select(string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IUserEventsCollectionRequest Select(Expression<Func<Event, object>> selectExpression)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IUserEventsCollectionRequest Skip(int value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IUserEventsCollectionRequest Top(int value)
+        {
+            throw new NotImplementedException();
+        }
+
+        public HttpRequestMessage GetHttpRequestMessage()
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockUserEventsCollectionRequest.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Mocks/MockUserEventsCollectionRequest.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Graph.DotnetCore.Test.Mocks
             return Task.FromResult<IUserEventsCollectionPage>(NextPage);
         }
 
+        public Task<IUserEventsCollectionPage> GetAsync(CancellationToken cancellationToken)
+        {
+            return this.GetAsync();
+        }
+
         #region Not impl
 
         public string ContentType { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
@@ -66,10 +71,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Mocks
         }
 
 
-        public Task<IUserEventsCollectionPage> GetAsync(CancellationToken cancellationToken)
-        {
-            throw new NotImplementedException();
-        }
+
 
         public IUserEventsCollectionRequest OrderBy(string value)
         {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/GraphTestBase.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/GraphTestBase.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
                 try
                 {
                     graphClient = new GraphServiceClient(
-                        "https://graph.microsoft.com/beta",
+                        "https://graph.microsoft.com/v1.0",
                         new DelegateAuthenticationProvider(
                             async (requestMessage) =>
                             {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Tasks/PageIteratorTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Tasks/PageIteratorTests.cs
@@ -1,0 +1,249 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.CSharp.RuntimeBinder;
+using Microsoft.Graph.DotnetCore.Test.Requests.Functional;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+/**
+
+Spec
+    https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/tasks/PageIteratorTask.md
+**/
+
+namespace Microsoft.Graph.DotnetCore.Test.Tasks
+{
+    public class PageIteratorTests : GraphTestBase
+    {
+        private PageIterator<Event> pageIterator;
+        private const string nextPageSubject = "";
+        
+        [Fact (Skip = "No CI set up for functional tests")]
+        public async Task PageIteratorDevTest()
+        {
+            // Get an initial page results to populate the iterator.
+            IUserEventsCollectionPage iUserEventsCollectionPage = await graphClient.Me.Events.Request().Top(2).GetAsync();
+            
+            // Create the function to process each entity returned in the pages
+            Func<Event,bool> processEachEvent = (e) =>
+            {
+                bool shouldContinue = true;
+
+                if (e.Subject.Contains("Latin"))
+                    shouldContinue = false;
+                Debug.WriteLine($"Event subject: {e.Subject}");
+                return shouldContinue;
+            }; 
+
+            // This requires the dev to specify the generic type in the CollectionPage.
+            pageIterator = PageIterator<Event>.CreatePageIterator(iUserEventsCollectionPage, processEachEvent);
+
+            await pageIterator.IterateAsync();
+        }
+
+        [Fact]
+        public async Task Given_Concrete_CollectionPage_It_Throws_RuntimeBinderException()
+        {
+            pageIterator = PageIterator<Event>.CreatePageIterator(new CollectionPage<Event>(), (e) => { return true; });
+            await Assert.ThrowsAsync<RuntimeBinderException>(() => pageIterator.IterateAsync());
+        }
+
+        [Fact]
+        public void Given_Null_CollectionPage_It_Throws_ArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => PageIterator<Event>.CreatePageIterator(null, (e) => { return true; }));
+        }
+
+        [Fact]
+        public void Given_Null_Delegate_It_Throws_ArgumentNullException()
+        {
+            Assert.Throws<ArgumentNullException>(() => PageIterator<Event>.CreatePageIterator(new CollectionPage<Event>(), null));
+        }
+
+        [Fact]
+        public async Task Given_Concrete_Generated_CollectionPage_It_Iterates_Page_Items()
+        {
+            int inputEventCount = 17;
+            var page = new UserEventsCollectionPage();
+            for (int i = 0; i < inputEventCount; i++)
+            {
+                page.Add(new Event() { Subject = $"Subject{i.ToString()}" });
+            }
+
+            List<Event> events = new List<Event>();
+
+            pageIterator = PageIterator<Event>.CreatePageIterator(page, (e) => 
+            {
+                events.Add(e);
+                return true;
+            });
+
+            await pageIterator.IterateAsync();
+
+            Assert.Equal(inputEventCount, events.Count);
+        }
+
+        [Fact]
+        public async Task Given_Concrete_Generated_CollectionPage_It_Stops_Iterating_Pageitems()
+        {
+            int inputEventCount = 17;
+            var page = new UserEventsCollectionPage();
+            for (int i = 0; i < inputEventCount; i++)
+            {
+                page.Add(new Event() { Subject = $"Subject{i.ToString()}" });
+            }
+
+            List<Event> events = new List<Event>();
+
+            pageIterator = PageIterator<Event>.CreatePageIterator(page, (e) =>
+            {
+                if (e.Subject == "Subject7")
+                    return false;
+                
+                events.Add(e);
+                return true;
+            });
+
+            await pageIterator.IterateAsync();
+
+            Assert.Equal(7, events.Count);
+        }
+
+        [Fact]
+        public async Task Given_CollectionPage_It_Stops_Iterating_Across_Pages()
+        {
+            // Create the 17 events to initiallize the original collection page.
+            List<Event> testEvents = new List<Event>();
+            int inputEventCount = 17;
+            for (int i = 0; i < inputEventCount; i++)
+            {
+                testEvents.Add(new Event() { Subject = $"Subject{i.ToString()}" });
+            }
+
+            // Create the 5 events to initialize the next collection page.
+            UserEventsCollectionPage nextPage = new UserEventsCollectionPage();
+            int nextPageEventCount = 5;
+            for (int i = 0; i < nextPageEventCount; i++)
+            {
+                nextPage.Add(new Event() { Subject = $"Subject for next page events: {i.ToString()}" });
+            }
+
+            // Create the CancellationTokenSource to test the cancellation of paging in the delegate.
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            var pagingToken = cancellationTokenSource.Token;
+
+            // Create the delegate to process each entity returned in the pages. The delegate will cancel 
+            // paging when the target subject is encountered.
+            Func<Event, bool> processEachEvent = (e) =>
+            {
+                bool shouldContinue = true;
+
+                if (e.Subject.Contains("Subject3"))
+                {
+                    cancellationTokenSource.Cancel();
+                }
+
+                if (e.Subject.Contains("Subject for next page events"))
+                {
+                    Assert.True(false, "Unexpectedly paged the next page of results.");
+                }
+
+                return shouldContinue;
+            };
+
+            Mocks.MockUserEventsCollectionRequest mockUserEventsCollectionRequest = new Mocks.MockUserEventsCollectionRequest(nextPage);
+            var mockUserEventsCollectionPage = new Mocks.MockUserEventsCollectionPage(testEvents, mockUserEventsCollectionRequest) as IUserEventsCollectionPage;
+
+            pageIterator = PageIterator<Event>.CreatePageIterator(mockUserEventsCollectionPage, processEachEvent);
+            await pageIterator.IterateAsync(pagingToken);
+
+            Assert.True(cancellationTokenSource.IsCancellationRequested, "The delegate page iterator did not cancel requests to fetch more pages.");
+        }
+
+        [Fact]
+        public async Task Given_CollectionPage_It_Iterates_Across_Pages()
+        {
+            // Create the 17 events to initiallize the original collection page.
+            List<Event> originalCollectionPageEvents = new List<Event>();
+            int inputEventCount = 17;
+            for (int i = 0; i < inputEventCount; i++)
+            {
+                originalCollectionPageEvents.Add(new Event() { Subject = $"Subject{i.ToString()}" });
+            }
+
+            // Create the 5 events to initialize the next collection page.
+            UserEventsCollectionPage nextPage = new UserEventsCollectionPage();
+            int nextPageEventCount = 5;
+            for (int i = 0; i < nextPageEventCount; i++)
+            {
+                nextPage.Add(new Event() { Subject = $"Subject for next page events: {i.ToString()}" });
+            }
+
+            bool reachedNextPage = false;
+
+            // Create the delegate to process each entity returned in the pages. The delegate will 
+            // signal that we reached an event in the next page.
+            Func<Event, bool> processEachEvent = (e) =>
+            {
+                bool shouldContinue = true;
+
+                if (e.Subject.Contains("Subject for next page events"))
+                {
+                    reachedNextPage = true;
+                }
+
+                return shouldContinue;
+            };
+
+            Mocks.MockUserEventsCollectionRequest mockUserEventsCollectionRequest = new Mocks.MockUserEventsCollectionRequest(nextPage);
+            var mockUserEventsCollectionPage = new Mocks.MockUserEventsCollectionPage(originalCollectionPageEvents, mockUserEventsCollectionRequest) as IUserEventsCollectionPage;
+
+            pageIterator = PageIterator<Event>.CreatePageIterator(mockUserEventsCollectionPage, processEachEvent);
+            await pageIterator.IterateAsync();
+
+            Assert.True(reachedNextPage, "The delegate page iterator did not reach the next page.");
+        }
+
+        [Fact] 
+        public async Task Given_CollectionPage_It_Handles_Empty_NextPage()
+        {
+            try
+            {
+                // Create the 17 events to initiallize the original collection page.
+                List<Event> originalCollectionPageEvents = new List<Event>();
+                int inputEventCount = 17;
+                for (int i = 0; i < inputEventCount; i++)
+                {
+                    originalCollectionPageEvents.Add(new Event() { Subject = $"Subject{i.ToString()}" });
+                }
+
+                // Create empty next collection page.
+                UserEventsCollectionPage nextPage = new UserEventsCollectionPage();
+
+                // Create the delegate to process each entity returned in the pages. 
+                Func<Event, bool> processEachEvent = (e) =>
+                {
+                    return true;
+                };
+                
+                Mocks.MockUserEventsCollectionRequest mockUserEventsCollectionRequest = new Mocks.MockUserEventsCollectionRequest(nextPage);
+                var mockUserEventsCollectionPage = new Mocks.MockUserEventsCollectionPage(originalCollectionPageEvents, mockUserEventsCollectionRequest) as IUserEventsCollectionPage;
+
+                pageIterator = PageIterator<Event>.CreatePageIterator(mockUserEventsCollectionPage, processEachEvent);
+                await pageIterator.IterateAsync();
+            }
+            catch (Exception)
+            {
+                Assert.True(false, "Unexpected exception occurred when next page contains no elements.");
+            }
+        }
+        // Given_Delta_Query_CollectionPage_It_Returns_Deltalink
+        // Given_DeltaLink_We_Can_Resume_PageItem_Iteration_And_Result_Paging
+    }
+}


### PR DESCRIPTION
### Changes proposed in this pull request
- Iterate and process the contents of a single page of a paged result set.
- Cancel and resume iteration.
- Store deltaLink in the iterator so that the iterator can be resumed at a indeterminate time in the future.

### Usage

**Page results until a result item contains the word 'fire'**

```csharp

// Get an initial page results to populate the iterator.
IUserEventsCollectionPage iUserEventsCollectionPage = await graphClient.Me
                                                                       .Events
                                                                       .Request()
                                                                       .Top(2)
                                                                       .GetAsync();
            
// Create the callback to process each entity returned in the pages
Func<Event,bool> processEachEvent = (e) =>
{
    bool shouldContinue = true;
    if (e.Subject.Contains("fire"))
        shouldContinue = false;
    return shouldContinue;
}; 

// Create the iterator with the specified type
eventPageIterator = PageIterator<Event>.CreatePageIterator(graphClient, 
                                                           iUserEventsCollectionPage, 
                                                           processEachEvent);

await eventPageIterator.IterateAsync();

```

**Resume delta query after changes**
```csharp

// Get an initial page results to populate the iterator.
var messagesDeltaCollectionPage = await graphClient.Me
                                                    .MailFolders["inbox"]
                                                    .Messages
                                                    .Delta()
                                                    .Request()
                                                    .GetAsync();
           
// Create the function to process each entity returned in the pages
Func<Message, bool> processEachMessage = (e) =>
{
    Debug.WriteLine($"Message subject: {e.Subject}");
    return true;
};

// This requires the dev to specify the generic type in the CollectionPage.
var messagePageIterator = PageIterator<Message>.CreatePageIterator(graphClient, 
                                                messagesDeltaCollectionPage, 
                                                processEachMessage);

await messagePageIterator.IterateAsync();

var me = await graphClient.Me.Request().GetAsync();
var recipients = new List<Recipient>()
{
    new Recipient()
    {
        EmailAddress = new EmailAddress()
        {
            Address = me.Mail
        }
    }
};

var message = new Message()
{
    Subject = "Message sent after deltatoken received.",
    ToRecipients = recipients
};
await graphClient.Me.SendMail(message, true).Request().PostAsync();

await Task.Delay(3000); // Arbitrary time - for demo purposes, we need to let the watermark get updated before we try to resume.

await messagePageIterator.ResumeAsync();

```

### Other links
- [Javascript PageIterator](https://github.com/microsoftgraph/msgraph-sdk-javascript/blob/dev/src/tasks/PageIterator.ts#L169)
- [Page Iterator spec](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/tasks/PageIteratorTask.md)
- [Page iterator sample](https://github.com/microsoftgraph/consoleApp-deltaQuery-dotNet-sample/blob/master/ConsoleApplication/Program.cs#L120)