### PR TITLE
Add request content headers to cloned http request.

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
@@ -61,20 +61,22 @@ namespace Microsoft.Graph
         {
             var newRequest = new HttpRequestMessage(originalRequest.Method, originalRequest.RequestUri);
 
+            // Copy request headers.
             foreach (var header in originalRequest.Headers)
-            {
                 newRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
-            }
 
+            // Copy request properties.
             foreach (var property in originalRequest.Properties)
-            {
                 newRequest.Properties.Add(property);
-            }
 
-            // Set Content if previous request contains
-            if (originalRequest.Content != null && originalRequest.Content.Headers.ContentLength != 0)
+            // Set Content if previous request had one.
+            if (originalRequest.Content != null)
             {
                 newRequest.Content = new StreamContent(await originalRequest.Content.ReadAsStreamAsync());
+
+                // Copy content headers.
+                foreach (var contentHeader in originalRequest.Content.Headers)
+                    newRequest.Content.Headers.TryAddWithoutValidation(contentHeader.Key, contentHeader.Value);
             }
 
             return newRequest;

--- a/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpRequestMessageExtensions.cs
@@ -75,8 +75,9 @@ namespace Microsoft.Graph
                 newRequest.Content = new StreamContent(await originalRequest.Content.ReadAsStreamAsync());
 
                 // Copy content headers.
-                foreach (var contentHeader in originalRequest.Content.Headers)
-                    newRequest.Content.Headers.TryAddWithoutValidation(contentHeader.Key, contentHeader.Value);
+                if (originalRequest.Content.Headers != null)
+                    foreach (var contentHeader in originalRequest.Content.Headers)
+                        newRequest.Content.Headers.TryAddWithoutValidation(contentHeader.Key, contentHeader.Value);
             }
 
             return newRequest;

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/HttpRequestMessageExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/HttpRequestMessageExtensionsTests.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
 {
     using Microsoft.Graph.DotnetCore.Core.Test.Requests;
     using System.Net.Http;
+    using System.Text;
+    using System.Threading.Tasks;
     using Xunit;
     public class HttpRequestMessageExtensionsTests: BaseRequestTests
     {
@@ -84,6 +86,34 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
             HttpRequestMessage httpRequestMessage = baseRequest.GetHttpRequestMessage();
 
             Assert.NotNull(httpRequestMessage.GetMiddlewareOption<AuthenticationHandlerOption>());
+        }
+
+        [Fact]
+        public async Task CloneAsync_WithEmptyHttpContent()
+        {
+            HttpRequestMessage originalRequest = new HttpRequestMessage(HttpMethod.Post, "http://example.com");
+
+            HttpRequestMessage clonedRequest = await originalRequest.CloneAsync();
+
+            Assert.NotNull(clonedRequest);
+            Assert.Equal(originalRequest.Method, clonedRequest.Method);
+            Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
+            Assert.Null(clonedRequest.Content);
+        }
+
+        [Fact]
+        public async Task CloneAsync_WithHttpContent()
+        {
+            HttpRequestMessage originalRequest = new HttpRequestMessage(HttpMethod.Post, "http://example.com");
+            originalRequest.Content = new StringContent("Sample Content", Encoding.UTF8, "application/json");
+
+            HttpRequestMessage clonedRequest = await originalRequest.CloneAsync();
+
+            Assert.NotNull(clonedRequest);
+            Assert.Equal(originalRequest.Method, clonedRequest.Method);
+            Assert.Equal(originalRequest.RequestUri, clonedRequest.RequestUri);
+            Assert.Equal(await originalRequest.Content.ReadAsStringAsync(), await clonedRequest.Content.ReadAsStringAsync());
+            Assert.Equal(originalRequest.Content.Headers.ContentType, clonedRequest.Content.Headers.ContentType);
         }
     }
 }


### PR DESCRIPTION
This PR is a fix for #435.

### Changes proposed in this pull request
- Adds content request headers to cloned http request contents.
- Adds unit tests for CloneAsync.