### PR TITLE
Public Graph Client Factory

### DIFF
--- a/src/Microsoft.Graph.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpClientExtensions.cs
@@ -9,15 +9,26 @@ namespace Microsoft.Graph
 
     internal static class HttpClientExtensions
     {
+        /// <summary>
+        /// Adds featureflag to existing header values.
+        /// </summary>
+        /// <param name="httpClient">The http client to set FeatureUsage header.</param>
+        /// <param name="featureFlag">The Feature usage flag to set.</param>
         internal static void SetFeatureFlag(this HttpClient httpClient, FeatureFlag featureFlag)
         {
+            // If feature flag header exists, add incoming flag to existing bitfield values and replace existing header with the computed bitfield total.
             if (httpClient.DefaultRequestHeaders.TryGetValues(CoreConstants.Headers.FeatureFlag, out var flags))
             {
+                // Add incoming flag to existing feature flag values.
                 foreach (var flag in flags)
                     if (Enum.TryParse(flag, out FeatureFlag targetFeatureFlag))
                         featureFlag |= targetFeatureFlag;
+
+                // Remove current header value.
+                httpClient.DefaultRequestHeaders.Remove(CoreConstants.Headers.FeatureFlag);
             }
 
+            // Add/Replace new computed bitfield.
             httpClient.DefaultRequestHeaders.Add(CoreConstants.Headers.FeatureFlag, Enum.Format(typeof(FeatureFlag), featureFlag, "x"));
         }
     }

--- a/src/Microsoft.Graph.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpClientExtensions.cs
@@ -9,8 +9,15 @@ namespace Microsoft.Graph
 
     internal static class HttpClientExtensions
     {
-        internal static void SetFeatureFlags(this HttpClient httpClient, FeatureFlag featureFlag)
+        internal static void SetFeatureFlag(this HttpClient httpClient, FeatureFlag featureFlag)
         {
+            if (httpClient.DefaultRequestHeaders.TryGetValues(CoreConstants.Headers.FeatureFlag, out var flags))
+            {
+                foreach (var flag in flags)
+                    if (Enum.TryParse(flag, out FeatureFlag targetFeatureFlag))
+                        featureFlag |= targetFeatureFlag;
+            }
+
             httpClient.DefaultRequestHeaders.Add(CoreConstants.Headers.FeatureFlag, Enum.Format(typeof(FeatureFlag), featureFlag, "x"));
         }
     }

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// GraphClientFactory class to create the HTTP client
     /// </summary>
-    internal static class GraphClientFactory
+    public static class GraphClientFactory
     {
         /// The key for the SDK version header.
         private static readonly string SdkVersionHeaderName = CoreConstants.Headers.SdkVersionHeaderName;
@@ -40,7 +40,7 @@ namespace Microsoft.Graph
         private static readonly Dictionary<string, string> cloudList = new Dictionary<string, string>
             {
                 { Global_Cloud, "https://graph.microsoft.com" },
-                { USGOV_Cloud, "https://graph.microsoft.com" },
+                { USGOV_Cloud, "https://graph.microsoft.us" },
                 { China_Cloud, "https://microsoftgraph.chinacloudapi.cn" },
                 { Germany_Cloud, "https://graph.microsoft.de" }
             };
@@ -192,38 +192,5 @@ namespace Microsoft.Graph
 
             return pipeline;
         }
-
-
-
-        ///// <summary>
-        ///// Configure an instance of an <see cref="HttpClient"/>
-        ///// </summary>
-        ///// <param name="client">The <see cref="HttpClient"/> client instance need to be configured.</param>
-        ///// <param name="timeout">A <see cref="TimeSpan"/> value for the HTTP client timeout property.</param>
-        ///// <param name="baseAddress">A <see cref="Uri"/> value to set the HTTP client BaseAddress property.</param>
-        ///// <param name="cacheControlHeaderValue">A <see cref="CacheControlHeaderValue"/> value to set HTTP client DefaultRequestHeaders property.</param>
-        ///// <returns></returns>
-        //public static HttpClient Configure(HttpClient client, TimeSpan timeout, Uri baseAddress, CacheControlHeaderValue cacheControlHeaderValue)
-        //{
-        //    try
-        //    {
-        //        client.Timeout = timeout;
-        //    }
-        //    catch (InvalidOperationException exception)
-        //    {
-        //        throw new ServiceException(
-        //            new Error
-        //            {
-        //                Code = ErrorConstants.Codes.NotAllowed,
-        //                Message = ErrorConstants.Messages.OverallTimeoutCannotBeSet,
-        //            },
-        //            exception);
-        //    }
-
-        //    client.BaseAddress = baseAddress == null ? new Uri(_baseAddress + Version) : baseAddress;
-        //    client.DefaultRequestHeaders.CacheControl = cacheControlHeaderValue ?? new CacheControlHeaderValue { NoCache = true, NoStore = true };
-        //    return client;
-        //}
-
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -61,19 +61,9 @@ namespace Microsoft.Graph
             this.httpMessageHandler = httpMessageHandler ?? new HttpClientHandler { AllowAutoRedirect = false };
             this.Serializer = serializer ?? new Serializer();
 
-            // Always ensure RedirectHandler is the last handler in your pipeline.
-            // The recommended DelegatingHandler order is : 1. AuthenticationHandler, 2. RetryHandler, 3.RedirectHandler.
-            DelegatingHandler[] handlers = new DelegatingHandler[]
-            {
-                new AuthenticationHandler(null),
-                new CompressionHandler(),
-                new RetryHandler(),
-                new RedirectHandler()
-            };
-
             GraphClientFactory.DefaultHttpHandler = () => this.httpMessageHandler;
-            this.httpClient = GraphClientFactory.Create("v1.0", GraphClientFactory.Global_Cloud, handlers);
-            this.httpClient.SetFeatureFlags(FeatureFlag.AuthHandler | FeatureFlag.CompressionHandler | FeatureFlag.RetryHandler | FeatureFlag.RedirectHandler | FeatureFlag.DefaultHttpProvider);
+            this.httpClient = GraphClientFactory.Create((IAuthenticationProvider)null, "v1.0", GraphClientFactory.Global_Cloud);
+            this.httpClient.SetFeatureFlag(FeatureFlag.DefaultHttpProvider);
         }
 
         /// <summary>

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/HttpClientExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/HttpClientExtensionsTests.cs
@@ -1,0 +1,43 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.Graph.DotnetCore.Core.Test.Extensions
+{
+    using System;
+    using System.Linq;
+    using System.Net.Http;
+    using Xunit;
+    public class HttpClientExtensionsTests
+    {
+        [Fact]
+        public void SetFeatureFlag_should_add_new_flag_to_featureflag_header()
+        {
+            HttpClient client = new HttpClient();
+            client.SetFeatureFlag(FeatureFlag.LongRunnungOperationHandler);
+
+            string expectedHeaderValue = Enum.Format(typeof(FeatureFlag), FeatureFlag.LongRunnungOperationHandler, "x");
+
+            Assert.True(client.DefaultRequestHeaders.Contains(CoreConstants.Headers.FeatureFlag));
+            Assert.True(client.DefaultRequestHeaders.GetValues(CoreConstants.Headers.FeatureFlag).Count().Equals(1));
+            Assert.Equal(client.DefaultRequestHeaders.GetValues(CoreConstants.Headers.FeatureFlag).First(), expectedHeaderValue);
+        }
+
+        [Fact]
+        public void SetFeatureFlag_should_add_flag_to_existing_featureflag_header_values()
+        {
+            FeatureFlag flags = FeatureFlag.AuthHandler | FeatureFlag.CompressionHandler | FeatureFlag.RetryHandler | FeatureFlag.RedirectHandler;
+
+            HttpClient client = new HttpClient();
+            client.DefaultRequestHeaders.Add(CoreConstants.Headers.FeatureFlag, Enum.Format(typeof(FeatureFlag), FeatureFlag.DefaultHttpProvider, "x"));
+            client.SetFeatureFlag(flags);
+
+            // 0000004F
+            string expectedHeaderValue = Enum.Format(typeof(FeatureFlag), flags |= FeatureFlag.DefaultHttpProvider, "x");
+
+            Assert.True(client.DefaultRequestHeaders.Contains(CoreConstants.Headers.FeatureFlag));
+            Assert.True(client.DefaultRequestHeaders.GetValues(CoreConstants.Headers.FeatureFlag).Count().Equals(1));
+            Assert.Equal(client.DefaultRequestHeaders.GetValues(CoreConstants.Headers.FeatureFlag).First(), expectedHeaderValue);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/OneDriveTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/OneDriveTests.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -74,26 +73,6 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
         //    Assert.True(false, "Something happened, check out a trace. Error code: " + e.Error.Code);
         //}
         //}
-
-        [Fact]
-        public async System.Threading.Tasks.Task GetItem()
-        {
-            try
-            {
-                HttpClient client = new HttpClient();
-                client.BaseAddress = new Uri("https://graph.microsoft.com/v1.0");
-
-                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "/me");
-                await client.SendAsync(request);
-
-                HttpRequestMessage request2 = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/beta/me");
-                await client.SendAsync(request2);
-            }
-            catch (Exception ex)
-            {
-                throw ex;
-            }
-        }
 
         [Fact(Skip = "No CI set up for functional tests")]
         public async System.Threading.Tasks.Task OneDriveNextPageRequest()

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/OneDriveTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/OneDriveTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -74,6 +75,25 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
         //}
         //}
 
+        [Fact]
+        public async System.Threading.Tasks.Task GetItem()
+        {
+            try
+            {
+                HttpClient client = new HttpClient();
+                client.BaseAddress = new Uri("https://graph.microsoft.com/v1.0");
+
+                HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, "/me");
+                await client.SendAsync(request);
+
+                HttpRequestMessage request2 = new HttpRequestMessage(HttpMethod.Get, "https://graph.microsoft.com/beta/me");
+                await client.SendAsync(request2);
+            }
+            catch (Exception ex)
+            {
+                throw ex;
+            }
+        }
 
         [Fact(Skip = "No CI set up for functional tests")]
         public async System.Threading.Tasks.Task OneDriveNextPageRequest()


### PR DESCRIPTION
This PR makes `GraphClientFactory` public.

### Changes proposed in this pull request
- Add `AuthenticationHandler` to default handlers.
- Accept `IAuthenticationProvider` when creating default handlers and creating a new `HttpClient`.
- Make `GraphClientFactory` public.
- Update unit tests to reflect changes.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- Graph client factory [design doc](https://github.com/microsoftgraph/msgraph-sdk-design/blob/master/GraphClientFactory.md).