### PR TITLE
Client Factory Refactor

### DIFF
--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -63,6 +63,8 @@ namespace Microsoft.Graph
 
             internal static string InvalidDependsOnRequestId = "Corresponding batch request id not found for the specified dependsOn relation.";
 
+            internal static string InvalidProxyArgument = "Proxy cannot be set more once. Proxy can only be set on the proxy or defaultHttpHandler argument and not both.";
+
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
+++ b/src/Microsoft.Graph.Core/Exceptions/ErrorConstants.cs
@@ -63,8 +63,7 @@ namespace Microsoft.Graph
 
             internal static string InvalidDependsOnRequestId = "Corresponding batch request id not found for the specified dependsOn relation.";
 
-            internal static string InvalidProxyArgument = "Proxy cannot be set more once. Proxy can only be set on the proxy or defaultHttpHandler argument and not both.";
-
+            public static string InvalidProxyArgument = "Proxy cannot be set more once. Proxy can only be set on the proxy or defaultHttpHandler argument and not both.";
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Extensions/HttpClientExtensions.cs
+++ b/src/Microsoft.Graph.Core/Extensions/HttpClientExtensions.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Graph
 {
     using System;
+    using System.Linq;
     using System.Net.Http;
 
     internal static class HttpClientExtensions
@@ -20,8 +21,8 @@ namespace Microsoft.Graph
             if (httpClient.DefaultRequestHeaders.TryGetValues(CoreConstants.Headers.FeatureFlag, out var flags))
             {
                 // Add incoming flag to existing feature flag values.
-                foreach (var flag in flags)
-                    if (Enum.TryParse(flag, out FeatureFlag targetFeatureFlag))
+                foreach (string flag in flags)
+                    if (Enum.TryParse(Convert.ToInt32(flag, 16).ToString(), out FeatureFlag targetFeatureFlag))
                         featureFlag |= targetFeatureFlag;
 
                 // Remove current header value.
@@ -30,6 +31,22 @@ namespace Microsoft.Graph
 
             // Add/Replace new computed bitfield.
             httpClient.DefaultRequestHeaders.Add(CoreConstants.Headers.FeatureFlag, Enum.Format(typeof(FeatureFlag), featureFlag, "x"));
+        }
+
+        /// <summary>
+        /// Checks if a featureflag existing in the default header values.
+        /// </summary>
+        /// <param name="httpClient">The http client to set FeatureUsage header.</param>
+        /// <param name="featureFlag">The Feature usage flag to check for.</param>
+        internal static bool ContainsFeatureFlag(this HttpClient httpClient, FeatureFlag featureFlag)
+        {
+            if (httpClient.DefaultRequestHeaders.TryGetValues(CoreConstants.Headers.FeatureFlag, out var flags))
+            {
+                string flag = flags.FirstOrDefault();
+                if (Enum.TryParse(Convert.ToInt32(flag, 16).ToString(), out FeatureFlag targetFeatureFlag))
+                    return targetFeatureFlag.HasFlag(featureFlag);
+            }
+            return false;
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -20,22 +20,14 @@
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <VersionPrefix>1.15.0</VersionPrefix>
-    <VersionSuffix>preview.1</VersionSuffix>
-    <PackageReleaseNotes>April 2019 Release Summary (version 1.15.0 preview.1)
-
-New Features:
-Added Graph client factory to create HTTP clients that are pre-configured to make requests to Graph APIs.
-Added batch request content that make is easy to create payloads for a Graph batch request.
-Added batch response content to process batch responses from Graph.
-Added compression middleware handler to request, detect and decompress response bodies from Graph service.
-Added response handler to process native HTTP response messages to strongly typed Graph objects.
+    <VersionSuffix>preview.2</VersionSuffix>
+    <PackageReleaseNotes>April 2019 Release Summary (version 1.15.0 preview.2)
 
 Fixes:
-Fixed issue #136.
-Fixed issue #205.
-Fixed issue #401.
-Fixed issue #431.
+Fixed issue #413.
 Fixed issue #435.
+Fixed issue #447.
+Fixed issue #449.
 </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard1.1|AnyCPU'">

--- a/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
+++ b/src/Microsoft.Graph.Core/Microsoft.Graph.Core.csproj
@@ -67,4 +67,7 @@ Fixed issue #435.
       <PackagePath></PackagePath>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+  </ItemGroup>
 </Project>

--- a/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
+++ b/src/Microsoft.Graph.Core/Requests/BaseRequest.cs
@@ -457,15 +457,15 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
-        /// Checks if a custom IHttpProvider is used or our HttpProvider is used without an auth handler (flag).
+        /// Determins whether or not <see cref="BaseRequest"/> should authenticate the request or let <see cref="AuthenticationHandler"/> authenticate the request.
         /// </summary>
-        /// <returns></returns>
+        /// <returns>
+        /// TRUE: If a CUSTOM <see cref="IHttpProvider"/> or DEFAULT <see cref="HttpProvider"/> is used WITHOUT an <see cref="AuthenticationHandler"/>.
+        /// FALSE: If our DEFAULT <see cref="HttpProvider"/> is used WITH an <see cref="AuthenticationHandler"/>.
+        /// </returns>
         private bool ShouldAuthenticateRequest()
         {
-            if (this.Client.HttpProvider.GetType() != typeof(HttpProvider))
-                return true;
-            else
-                return !(this.Client.HttpProvider as HttpProvider).httpClient.ContainsFeatureFlag(FeatureFlag.AuthHandler);
+            return !(this.Client.HttpProvider is HttpProvider && (this.Client.HttpProvider as HttpProvider).httpClient.ContainsFeatureFlag(FeatureFlag.AuthHandler));
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Graph
                 throw new ClientException(new Error
                 {
                     Code = ErrorConstants.Codes.InvalidArgument,
-                    Message = "Proxy can only be set on the proxy or defaultHttpHandler argument and not both."
+                    Message = ErrorConstants.Messages.InvalidProxyArgument
                 });
             }
 
@@ -151,7 +151,7 @@ namespace Microsoft.Graph
         {
             if (innerHandler == null)
             {
-                innerHandler = new HttpClientHandler();
+                innerHandler = new HttpClientHandler { AllowAutoRedirect = false };
             }
 
             if (handlers == null)

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -146,6 +146,17 @@ namespace Microsoft.Graph
             return CreatePipelineWithFeatureFlags(handlers, innerHandler).Pipeline;
         }
 
+        /// <summary>
+        /// Creates an instance of an <see cref="HttpMessageHandler"/> using the <see cref="DelegatingHandler"/> instances
+        /// provided by <paramref name="handlers"/>. The resulting pipeline can be used to manually create <see cref="HttpClient"/>
+        /// or <see cref="HttpMessageInvoker"/> instances with customized message handlers.
+        /// </summary>
+        /// <param name="innerHandler">The inner handler represents the destination of the HTTP message channel.</param>
+        /// <param name="handlers">An ordered list of <see cref="DelegatingHandler"/> instances to be invoked as part
+        /// of sending an <see cref="HttpRequestMessage"/> and receiving an <see cref="HttpResponseMessage"/>.
+        /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for
+        /// an outbound request message but last for an inbound response message.</param>
+        /// <returns>A tuple with The HTTP message channel and FeatureFlag for the handlers.</returns>
         internal static (HttpMessageHandler Pipeline, FeatureFlag FeatureFlags) CreatePipelineWithFeatureFlags(IEnumerable<DelegatingHandler> handlers, HttpMessageHandler innerHandler = null)
         {
             FeatureFlag handlerFlags = FeatureFlag.None;
@@ -183,7 +194,11 @@ namespace Microsoft.Graph
             return (Pipeline: httpPipeline, FeatureFlags: handlerFlags);
         }
 
-
+        /// <summary>
+        /// Gets feature flag for the specified handler.
+        /// </summary>
+        /// <param name="delegatingHandler">The <see cref="DelegatingHandler"/> to get its feaure flag.</param>
+        /// <returns>Delegating handler feature flag.</returns>
         private static FeatureFlag GetHandlerFeatureFlag(DelegatingHandler delegatingHandler)
         {
             FeatureFlag featureFlag = FeatureFlag.None;

--- a/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
+++ b/src/Microsoft.Graph.Core/Requests/GraphClientFactory.cs
@@ -33,8 +33,6 @@ namespace Microsoft.Graph
         /// The default value for the overall request timeout.
         private static readonly TimeSpan defaultTimeout = TimeSpan.FromSeconds(100);
 
-        /// The default value for the baseAddress of HTTP client
-        private static readonly string _baseAddress = "https://graph.microsoft.com/";
 
         /// Microsoft Graph service nationa cloud endpoints
         private static readonly Dictionary<string, string> cloudList = new Dictionary<string, string>
@@ -57,32 +55,24 @@ namespace Microsoft.Graph
         public const string Germany_Cloud = "Germany";
 
         /// <summary>
-        /// Proxy to be used with created clients
-        /// </summary>
-        public static IWebProxy Proxy { get; set; }
-
-        /// <summary>
-        /// DefaultHandler is a Func that returns the HttpMessageHandler for actually making the HTTP calls.
-        /// The default implementation returns a new instance of HttpClientHandler for each HttpClient.
-        /// </summary>
-        public static Func<HttpMessageHandler> DefaultHttpHandler = () => {
-            return new HttpClientHandler
-            {
-                Proxy = Proxy
-            };
-        };
-
-        /// <summary>
         /// Creates a new <see cref="HttpClient"/> instance configured with the handlers provided.
         /// </summary>
         /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> to authenticate requests.</param>
         /// <param name="version">The graph version to use.</param>
         /// <param name="nationalCloud">The national cloud endpoint to use.</param>
+        /// <param name="proxy">The proxy to be used with created client.</param>
+        /// <param name="innerHandler">The last HttpMessageHandler to HTTP calls.
+        /// The default implementation creates a new instance of <see cref="HttpClientHandler"/> for each HttpClient.</param>
         /// <returns></returns>
-        public static HttpClient Create(IAuthenticationProvider authenticationProvider, string version = "v1.0", string nationalCloud = Global_Cloud)
+        public static HttpClient Create(
+            IAuthenticationProvider authenticationProvider,
+            string version = "v1.0",
+            string nationalCloud = Global_Cloud,
+            IWebProxy proxy = null,
+            HttpMessageHandler innerHandler = null)
         {
-            HttpMessageHandler pipeline = CreatePipeline(CreateDefaultHandlers(authenticationProvider));
-            return Create(pipeline, version, nationalCloud);
+            IList<DelegatingHandler> handlers = CreateDefaultHandlers(authenticationProvider);
+            return Create(handlers, version, nationalCloud, proxy, innerHandler);
         }
 
         /// <summary>
@@ -95,22 +85,30 @@ namespace Microsoft.Graph
         /// <see cref="HttpResponseMessage"/> travels from the network back to <see cref="HttpClient"/>.
         /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for
         /// an outbound request message but last for an inbound response message.</param>
+        /// <param name="proxy">The proxy to be used with created client.</param>
+        /// <param name="innerHandler">The last HttpMessageHandler to HTTP calls.</param>
         /// <returns>An <see cref="HttpClient"/> instance with the configured handlers.</returns>
-        public static HttpClient Create(IEnumerable<DelegatingHandler> handlers, string version = "v1.0", string nationalCloud = Global_Cloud)
+        public static HttpClient Create(
+            IEnumerable<DelegatingHandler> handlers,
+            string version = "v1.0",
+            string nationalCloud = Global_Cloud,
+            IWebProxy proxy = null,
+            HttpMessageHandler innerHandler = null)
         {
-            HttpMessageHandler pipeline = CreatePipeline(handlers);
-            return Create(pipeline, version, nationalCloud);
-        }
+            if (innerHandler == null)
+                innerHandler = new HttpClientHandler { Proxy = proxy, AllowAutoRedirect = false };
+            else if ((innerHandler is HttpClientHandler) && (innerHandler as HttpClientHandler).Proxy == null && proxy != null)
+                (innerHandler as HttpClientHandler).Proxy = proxy;
+            else if ((innerHandler is HttpClientHandler) && (innerHandler as HttpClientHandler).Proxy != null && proxy != null)
+            {
+                throw new ClientException(new Error
+                {
+                    Code = ErrorConstants.Codes.InvalidArgument,
+                    Message = "Proxy can only be set on the proxy or defaultHttpHandler argument and not both."
+                });
+            }
 
-        /// <summary>
-        /// Creates a new <see cref="HttpClient"/> instance configured with the handlers provided.
-        /// </summary>
-        /// <param name="pipeline">The message handler that represents the HTTP pipeline.</param>
-        /// <param name="version">The graph version to use.</param>
-        /// <param name="nationalCloud">The national cloud endpoint to use.</param>
-        /// <returns></returns>
-        internal static HttpClient Create(HttpMessageHandler pipeline, string version = "v1.0", string nationalCloud = Global_Cloud)
-        {
+            HttpMessageHandler pipeline = CreatePipeline(handlers, innerHandler);
             HttpClient client = new HttpClient(pipeline);
             client.DefaultRequestHeaders.Add(SdkVersionHeaderName, SdkVersionHeaderValue);
             client.SetFeatureFlag(featureFlags);
@@ -137,17 +135,6 @@ namespace Microsoft.Graph
             };
         }
 
-        private static Uri DetermineBaseAddress(string nationalCloud, string version)
-        {
-            string cloud = "";
-            if (!cloudList.TryGetValue(nationalCloud, out cloud))
-            {
-                throw new ArgumentException(String.Format("{0} is an unexpected national cloud.", nationalCloud, "nationalCloud"));
-            }
-            string cloudAddress = cloud + "/" + version;
-            return new Uri(cloudAddress);
-
-        }
 
         /// <summary>
         /// Creates an instance of an <see cref="HttpMessageHandler"/> using the <see cref="DelegatingHandler"/> instances
@@ -160,11 +147,11 @@ namespace Microsoft.Graph
         /// The handlers are invoked in a top-down fashion. That is, the first entry is invoked first for
         /// an outbound request message but last for an inbound response message.</param>
         /// <returns>The HTTP message channel.</returns>
-        public static HttpMessageHandler CreatePipeline(IEnumerable<DelegatingHandler> handlers, HttpMessageHandler innerHandler = null )
+        public static HttpMessageHandler CreatePipeline(IEnumerable<DelegatingHandler> handlers, HttpMessageHandler innerHandler = null)
         {
             if (innerHandler == null)
             {
-                innerHandler = DefaultHttpHandler();
+                innerHandler = new HttpClientHandler();
             }
 
             if (handlers == null)
@@ -191,6 +178,18 @@ namespace Microsoft.Graph
             }
 
             return pipeline;
+        }
+
+        private static Uri DetermineBaseAddress(string nationalCloud, string version)
+        {
+            string cloud = "";
+            if (!cloudList.TryGetValue(nationalCloud, out cloud))
+            {
+                throw new ArgumentException(String.Format("{0} is an unexpected national cloud.", nationalCloud, "nationalCloud"));
+            }
+            string cloudAddress = cloud + "/" + version;
+            return new Uri(cloudAddress);
+
         }
     }
 }

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
             this.httpMessageHandler = httpMessageHandler;
             this.Serializer = serializer ?? new Serializer();
 
-            // NOTE: Overide our pipeline when a httpMessageHandler is provided - httpMessageHandler can implement custom pipeline.
+            // NOTE: Override our pipeline when a httpMessageHandler is provided - httpMessageHandler can implement custom pipeline.
             // This check won't be needed once we re-write the HttpProvider to work with GraphClientFactory.
             if (this.httpMessageHandler == null)
             {

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Graph
             if (this.httpMessageHandler == null)
             {
                 this.httpMessageHandler = new HttpClientHandler { AllowAutoRedirect = false };
-                this.httpClient = GraphClientFactory.Create(authenticationProvider: null, version: "v1.0", nationalCloud: GraphClientFactory.Global_Cloud, innerHandler: httpMessageHandler);
+                this.httpClient = GraphClientFactory.Create(authenticationProvider: null, version: "v1.0", nationalCloud: GraphClientFactory.Global_Cloud, finalHandler: httpMessageHandler);
             }
             else
             {

--- a/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
+++ b/src/Microsoft.Graph.Core/Requests/HttpProvider.cs
@@ -58,11 +58,21 @@ namespace Microsoft.Graph
         public HttpProvider(HttpMessageHandler httpMessageHandler, bool disposeHandler, ISerializer serializer)
         {
             this.disposeHandler = disposeHandler;
-            this.httpMessageHandler = httpMessageHandler ?? new HttpClientHandler { AllowAutoRedirect = false };
+            this.httpMessageHandler = httpMessageHandler;
             this.Serializer = serializer ?? new Serializer();
 
-            GraphClientFactory.DefaultHttpHandler = () => this.httpMessageHandler;
-            this.httpClient = GraphClientFactory.Create((IAuthenticationProvider)null, "v1.0", GraphClientFactory.Global_Cloud);
+            // NOTE: Overide our pipeline when a httpMessageHandler is provided - httpMessageHandler can implement custom pipeline.
+            // This check won't be needed once we re-write the HttpProvider to work with GraphClientFactory.
+            if (this.httpMessageHandler == null)
+            {
+                this.httpMessageHandler = new HttpClientHandler { AllowAutoRedirect = false };
+                this.httpClient = GraphClientFactory.Create(authenticationProvider: null, version: "v1.0", nationalCloud: GraphClientFactory.Global_Cloud, innerHandler: httpMessageHandler);
+            }
+            else
+            {
+                this.httpClient = new HttpClient(this.httpMessageHandler, this.disposeHandler);
+            } 
+
             this.httpClient.SetFeatureFlag(FeatureFlag.DefaultHttpProvider);
         }
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/AuthenticationHandler.cs
@@ -126,12 +126,9 @@ namespace Microsoft.Graph
             }
             else
             {
-                throw new ServiceException(
-                    new Error
-                    {
-                        Code = ErrorConstants.Codes.InvalidRequest,
-                        Message = ErrorConstants.Messages.AuthenticationProviderMissing,
-                    });
+                // NOTE: In order to support HttpProvider, we'll skip authentication if no provider is set.
+                // We will add this check once we re-write a new HttpProvider.
+                return await base.SendAsync(httpRequestMessage, cancellationToken);
             }
         }
     }

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RedirectHandler.cs
@@ -70,6 +70,12 @@ namespace Microsoft.Graph
 
                 while (redirectCount < RedirectOption.MaxRedirect)
                 {
+                    // Drain response content to free responses.
+                    if (response.Content != null)
+                    {
+                        await response.Content.ReadAsByteArrayAsync();
+                    }
+
                     // general clone request with internal CloneAsync (see CloneAsync for details) extension method 
                     var newRequest = await response.RequestMessage.CloneAsync();
 

--- a/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
+++ b/src/Microsoft.Graph.Core/Requests/Middleware/RetryHandler.cs
@@ -79,6 +79,12 @@ namespace Microsoft.Graph
             int retryCount = 0;
             while (retryCount < RetryOption.MaxRetry)
             {
+                // Drain response content to free responses.
+                if (response.Content != null)
+                {
+                    await response.Content.ReadAsByteArrayAsync();
+                }
+
                 // Call Delay method to get delay time from response's Retry-After header or by exponential backoff 
                 Task delay = Delay(response, retryCount, RetryOption.Delay, cancellationToken);
 

--- a/tests/Microsoft.Graph.Core.Test/Extensions/BaseRequestExtensionsTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Extensions/BaseRequestExtensionsTests.cs
@@ -23,7 +23,11 @@
         {
             defaultAuthProvider = new MockAuthenticationProvider(defaultAuthHeader);
             testHttpMessageHandler = new TestHttpMessageHandler();
-            httpProvider = new HttpProvider(testHttpMessageHandler, true, serializer.Object);
+
+            var defaultHandlers = GraphClientFactory.CreateDefaultHandlers(defaultAuthProvider.Object);
+            var pipeline = GraphClientFactory.CreatePipeline(defaultHandlers, this.testHttpMessageHandler);
+
+            httpProvider = new HttpProvider(pipeline, true, serializer.Object);
             baseClient = new BaseClient("https://localhost/v1.0", defaultAuthProvider.Object, httpProvider);
         }
 

--- a/tests/Microsoft.Graph.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/BaseRequestTests.cs
@@ -240,6 +240,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             }
         }
 
+        [Ignore("In order to support HttpProvider, we'll skip authentication if no provider is set. We will add enable this once we re-write a new HttpProvider.")]
         [TestMethod]
         [ExpectedException(typeof(ServiceException))]
         public async Task SendAsync_AuthenticationProviderNotSet()

--- a/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -81,8 +81,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreatePipelineWithoutPipeline()
         {
-            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
-            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(handlers: handlers))
+            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(handlers: handlers, innerHandler: this.testHttpMessageHandler))
             {
                 Assert.IsNotNull(handler, "Create a middleware pipeline failed.");
                 Assert.IsInstanceOfType(handler, typeof(RetryHandler), "Inner most HttpMessageHandler class error.");
@@ -95,9 +94,9 @@ namespace Microsoft.Graph.Core.Test.Requests
             var timeout = TimeSpan.FromSeconds(200);
             var baseAddress = new Uri("https://localhost");
             var cacheHeader = new CacheControlHeaderValue();
-            GraphClientFactory.Proxy = new WebProxy("http://127.0.0.1:8888");
+            var proxy = new WebProxy("http://127.0.0.1:8888");
 
-            using (HttpClient client = GraphClientFactory.Create(authenticationProvider.Object))
+            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, proxy: proxy))
             {
                 client.Timeout = timeout;
                 client.BaseAddress = baseAddress;
@@ -137,8 +136,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreateClient_WithInnerHandler()
         {
-            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
-            using (HttpClient httpClient = GraphClientFactory.Create(authenticationProvider.Object))
+            using (HttpClient httpClient = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
             {
                 Assert.IsNotNull(httpClient, "Create Http client failed.");
                 Assert.IsTrue(httpClient.DefaultRequestHeaders.Contains(CoreConstants.Headers.SdkVersionHeaderName), "SDK version not set.");
@@ -176,9 +174,8 @@ namespace Microsoft.Graph.Core.Test.Requests
             redirectResponse.Headers.Location = new Uri("http://example.org/bar");
             var oKResponse = new HttpResponseMessage(HttpStatusCode.OK);
             this.testHttpMessageHandler.SetHttpResponse(redirectResponse, oKResponse);
-            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
 
-            using (HttpClient client = GraphClientFactory.Create(authenticationProvider.Object))
+            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreEqual(response, oKResponse, "Middleware pipeline not work.");
@@ -199,9 +196,8 @@ namespace Microsoft.Graph.Core.Test.Requests
             var response_2 = new HttpResponseMessage(HttpStatusCode.OK);
 
             this.testHttpMessageHandler.SetHttpResponse(retryResponse, response_2);
-            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
 
-            using (HttpClient client = GraphClientFactory.Create(authenticationProvider.Object))
+            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, response_2);
@@ -221,16 +217,14 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             var unauthorizedResponse = new HttpResponseMessage(HttpStatusCode.Unauthorized);
             var okResponse = new HttpResponseMessage(HttpStatusCode.OK);
+            IList<DelegatingHandler> handlersWithNoAuth = GraphClientFactory.CreateDefaultHandlers(null);
 
             testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, okResponse);
-            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
-
-            IList<DelegatingHandler> handlersWithNoAuth = GraphClientFactory.CreateDefaultHandlers(null);
 
             // Remove auth hander.
             handlersWithNoAuth.RemoveAt(0);
 
-            using (HttpClient client = GraphClientFactory.Create(handlersWithNoAuth))
+            using (HttpClient client = GraphClientFactory.Create(handlers: handlersWithNoAuth, innerHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, unauthorizedResponse);
@@ -251,9 +245,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             handlers[2] = new AuthenticationHandler(new MockAuthenticationProvider().Object);
 
-            GraphClientFactory.DefaultHttpHandler = () => this.testHttpMessageHandler;
-
-            using (HttpClient client = GraphClientFactory.Create( handlers: handlers))
+            using (HttpClient client = GraphClientFactory.Create( handlers: handlers, innerHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, okResponse);

--- a/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreatePipelineWithoutPipeline()
         {
-            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(handlers: handlers, innerHandler: this.testHttpMessageHandler))
+            using (RetryHandler handler = (RetryHandler)GraphClientFactory.CreatePipeline(handlers: handlers, finalHandler: this.testHttpMessageHandler))
             {
                 Assert.IsNotNull(handler, "Create a middleware pipeline failed.");
                 Assert.IsInstanceOfType(handler, typeof(RetryHandler), "Inner most HttpMessageHandler class error.");
@@ -112,7 +112,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             using (HttpClient httpClient = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, version: "beta", nationalCloud: GraphClientFactory.Germany_Cloud))
             {
                 Assert.IsNotNull(httpClient, "Create Http client failed.");
-                Uri clouldEndpoint = new Uri("https://graph.microsoft.de/beta");
+                Uri clouldEndpoint = new Uri("https://graph.microsoft.de/beta/");
                 Assert.AreEqual(httpClient.BaseAddress, clouldEndpoint, "Unexpected endpoint set.");
                 Assert.AreEqual(httpClient.Timeout, TimeSpan.FromSeconds(100), "Default timeout not set.");
             }
@@ -136,7 +136,7 @@ namespace Microsoft.Graph.Core.Test.Requests
         [TestMethod]
         public void CreateClient_WithInnerHandler()
         {
-            using (HttpClient httpClient = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient httpClient = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, finalHandler: this.testHttpMessageHandler))
             {
                 Assert.IsNotNull(httpClient, "Create Http client failed.");
                 Assert.IsTrue(httpClient.DefaultRequestHeaders.Contains(CoreConstants.Headers.SdkVersionHeaderName), "SDK version not set.");
@@ -175,7 +175,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             var oKResponse = new HttpResponseMessage(HttpStatusCode.OK);
             this.testHttpMessageHandler.SetHttpResponse(redirectResponse, oKResponse);
 
-            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, finalHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreEqual(response, oKResponse, "Middleware pipeline not work.");
@@ -197,7 +197,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             this.testHttpMessageHandler.SetHttpResponse(retryResponse, response_2);
 
-            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: authenticationProvider.Object, finalHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, response_2);
@@ -224,7 +224,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             // Remove auth hander.
             handlersWithNoAuth.RemoveAt(0);
 
-            using (HttpClient client = GraphClientFactory.Create(handlers: handlersWithNoAuth, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient client = GraphClientFactory.Create(handlers: handlersWithNoAuth, finalHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, unauthorizedResponse);
@@ -245,7 +245,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
             handlers[2] = new AuthenticationHandler(new MockAuthenticationProvider().Object);
 
-            using (HttpClient client = GraphClientFactory.Create( handlers: handlers, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient client = GraphClientFactory.Create( handlers: handlers, finalHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.AreSame(response, okResponse);

--- a/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/HttpProviderTests.cs
@@ -32,7 +32,10 @@ namespace Microsoft.Graph.Core.Test.Requests
             this.testHttpMessageHandler = new TestHttpMessageHandler();
             this.authProvider = new MockAuthenticationProvider();
 
-            this.httpProvider = new HttpProvider(this.testHttpMessageHandler, true, this.serializer.Object);
+            var defaultHandlers = GraphClientFactory.CreateDefaultHandlers(authProvider.Object);
+            var pipeline = GraphClientFactory.CreatePipeline(defaultHandlers, this.testHttpMessageHandler);
+
+            this.httpProvider = new HttpProvider(pipeline, true, this.serializer.Object);
         }
 
         [TestCleanup]
@@ -251,7 +254,7 @@ namespace Microsoft.Graph.Core.Test.Requests
 
                 var returnedResponseMessage = await this.httpProvider.SendAsync(httpRequestMessage);
 
-                Assert.AreEqual(6, finalResponseMessage.RequestMessage.Headers.Count(), "Unexpected number of headers on redirect request message.");
+                Assert.AreEqual(4, finalResponseMessage.RequestMessage.Headers.Count(), "Unexpected number of headers on redirect request message.");
                 
                 foreach (var header in httpRequestMessage.Headers)
                 {

--- a/tests/Microsoft.Graph.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
@@ -254,6 +254,7 @@ namespace Microsoft.Graph.Core.Test.Requests
             Assert.AreEqual(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello Mars!");
         }
 
+        [Ignore("In order to support HttpProvider, we'll skip authentication if no provider is set. We will add enable this once we re-write a new HttpProvider.")]
         [TestMethod]
         public async Task AuthHandler_ShouldThrowExceptionWhenAuthProviderIsNotSet()
         {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/BaseRequestExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Extensions/BaseRequestExtensionsTests.cs
@@ -23,7 +23,11 @@
         {
             defaultAuthProvider = new MockAuthenticationProvider(defaultAuthHeader);
             testHttpMessageHandler = new TestHttpMessageHandler();
-            httpProvider = new HttpProvider(testHttpMessageHandler, true, serializer.Object);
+
+            var defaultHandlers = GraphClientFactory.CreateDefaultHandlers(defaultAuthProvider.Object);
+            var pipeline = GraphClientFactory.CreatePipeline(defaultHandlers, this.testHttpMessageHandler);
+
+            httpProvider = new HttpProvider(pipeline, true, serializer.Object);
             baseClient = new BaseClient("https://localhost/v1.0", defaultAuthProvider.Object, httpProvider);
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/TestHttpMessageHandler.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Mocks/TestHttpMessageHandler.cs
@@ -13,10 +13,12 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
 {
     public class TestHttpMessageHandler : HttpMessageHandler
     {
+        private Action<HttpRequestMessage> requestMessageDelegate;
         private Dictionary<string, HttpResponseMessage> responseMessages;
 
-        public TestHttpMessageHandler()
+        public TestHttpMessageHandler(Action<HttpRequestMessage> requestMessage = null)
         {
+            this.requestMessageDelegate = requestMessage ?? DefaultRequestHandler;
             this.responseMessages = new Dictionary<string, HttpResponseMessage>();
         }
 
@@ -29,13 +31,20 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Mocks
         {
             HttpResponseMessage responseMessage;
 
+            requestMessageDelegate(request);
+
             if (this.responseMessages.TryGetValue(request.RequestUri.ToString(), out responseMessage))
             {
                 responseMessage.RequestMessage = request;
                 return Task.FromResult(responseMessage);
             }
 
-            return Task.FromResult<HttpResponseMessage>(null);
+            return Task.FromResult<HttpResponseMessage>(new HttpResponseMessage());
+        }
+
+        private void DefaultRequestHandler(HttpRequestMessage httpRequest)
+        {
+
         }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseClientTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseClientTests.cs
@@ -3,10 +3,6 @@
 // ------------------------------------------------------------------------------
 
 using Microsoft.Graph.DotnetCore.Core.Test.Mocks;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace Microsoft.Graph.DotnetCore.Core.Test.Requests

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/BaseRequestTests.cs
@@ -354,7 +354,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public async Task BaseRequest_Should_Call_HttpProvider_Concurrently()
         {
-            var tasks = Enumerable.Range(1, 1).Select(index =>
+            var tasks = Enumerable.Range(1, 50).Select(index =>
             {
                 return Task.Run(async () =>
                 {

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -280,5 +280,29 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             }
 
         }
+
+        [Fact]
+        public void CreatePipelineWithFeatureFlags_Should_Set_FeatureFlag_For_Default_Handlers()
+        {
+            FeatureFlag expectedFlag = FeatureFlag.AuthHandler | FeatureFlag.CompressionHandler | FeatureFlag.RetryHandler | FeatureFlag.RedirectHandler;
+            string expectedFlagHeaderValue = Enum.Format(typeof(FeatureFlag), expectedFlag, "x");
+            var handlers = GraphClientFactory.CreateDefaultHandlers(null);
+            var pipelineWithHandlers = GraphClientFactory.CreatePipelineWithFeatureFlags(handlers);
+
+            Assert.NotNull(pipelineWithHandlers.Pipeline);
+            Assert.True(pipelineWithHandlers.FeatureFlags.HasFlag(expectedFlag));
+        }
+
+        [Fact]
+        public void CreatePipelineWithFeatureFlags_Should_Set_FeatureFlag_For_Speficied_Handlers()
+        {
+            FeatureFlag expectedFlag = FeatureFlag.AuthHandler | FeatureFlag.CompressionHandler | FeatureFlag.RetryHandler;
+            var handlers = GraphClientFactory.CreateDefaultHandlers(null);
+            handlers.RemoveAt(3);
+            var pipelineWithHandlers = GraphClientFactory.CreatePipelineWithFeatureFlags(handlers);
+
+            Assert.NotNull(pipelineWithHandlers.Pipeline);
+            Assert.True(pipelineWithHandlers.FeatureFlags.HasFlag(expectedFlag));
+        }
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             using (HttpClient httpClient = GraphClientFactory.Create(testAuthenticationProvider.Object, version: "beta", nationalCloud: GraphClientFactory.Germany_Cloud))
             {
                 Assert.NotNull(httpClient);
-                Uri clouldEndpoint = new Uri("https://graph.microsoft.de/beta");
+                Uri clouldEndpoint = new Uri("https://graph.microsoft.de/beta/");
                 Assert.Equal(httpClient.BaseAddress, clouldEndpoint);
                 Assert.Equal(httpClient.Timeout, TimeSpan.FromSeconds(100));
             }
@@ -152,7 +152,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         [Fact]
         public void CreateClient_WithInnerHandler()
         {
-            using (HttpClient httpClient = GraphClientFactory.Create(authenticationProvider: testAuthenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient httpClient = GraphClientFactory.Create(authenticationProvider: testAuthenticationProvider.Object, finalHandler: this.testHttpMessageHandler))
             {
                 Assert.NotNull(httpClient);
                 Assert.True(httpClient.DefaultRequestHeaders.Contains(CoreConstants.Headers.SdkVersionHeaderName), "SDK version not set.");
@@ -189,7 +189,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             var oKResponse = new HttpResponseMessage(HttpStatusCode.OK);
             this.testHttpMessageHandler.SetHttpResponse(redirectResponse, oKResponse);
 
-            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: testAuthenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: testAuthenticationProvider.Object, finalHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.Equal(response, oKResponse);
@@ -211,7 +211,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             this.testHttpMessageHandler.SetHttpResponse(retryResponse, response_2);
 
-            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: testAuthenticationProvider.Object, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient client = GraphClientFactory.Create(authenticationProvider: testAuthenticationProvider.Object, finalHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.Same(response, response_2);
@@ -236,7 +236,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             IList<DelegatingHandler> handlersWithNoAuthProvider = GraphClientFactory.CreateDefaultHandlers(null);
 
-            using (HttpClient client = GraphClientFactory.Create(handlers: handlersWithNoAuthProvider, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient client = GraphClientFactory.Create(handlers: handlersWithNoAuthProvider, finalHandler: this.testHttpMessageHandler))
             {
                 ServiceException ex = await Assert.ThrowsAsync<ServiceException>(() => client.SendAsync(httpRequestMessage, new CancellationToken()));
                 Assert.Equal(ErrorConstants.Codes.InvalidRequest, ex.Error.Code);
@@ -255,7 +255,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
 
             testHttpMessageHandler.SetHttpResponse(unauthorizedResponse, okResponse);
 
-            using (HttpClient client = GraphClientFactory.Create(handlers: handlers, innerHandler: this.testHttpMessageHandler))
+            using (HttpClient client = GraphClientFactory.Create(handlers: handlers, finalHandler: this.testHttpMessageHandler))
             {
                 var response = await client.SendAsync(httpRequestMessage, new CancellationToken());
                 Assert.Same(response, okResponse);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/GraphClientFactoryTests.cs
@@ -95,6 +95,17 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
         }
 
         [Fact]
+        public void CreatePipeline_Should_Throw_Exception_With_Duplicate_Handlers()
+        {
+            var handlers = GraphClientFactory.CreateDefaultHandlers(testAuthenticationProvider.Object);
+            handlers.Add(new AuthenticationHandler(testAuthenticationProvider.Object));
+
+            ArgumentException exception =  Assert.Throws<ArgumentException>(() => GraphClientFactory.CreatePipeline(handlers));
+
+            Assert.Contains($"{typeof(AuthenticationHandler)} has a duplicate handler.", exception.Message);
+        }
+
+        [Fact]
         public void CreateClient_CustomHttpHandlingBehaviors()
         {
             var timeout = TimeSpan.FromSeconds(200);

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/HttpProviderTests.cs
@@ -470,24 +470,5 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
                 Assert.Equal(expectedToken, returnedResponseMessage.RequestMessage.Headers.Authorization.Parameter);
             }
         }
-
-        //[Fact]
-        //public async Task HttpProvider()
-        //{
-        //    string expectedToken = "send_with_custom_handler";
-        //    var authHandler = new AuthenticationHandler(new MockAuthenticationProvider(expectedToken).Object, this.testHttpMessageHandler);
-        //    using (var myHttpProvider = new HttpProvider(authHandler, true, new Serializer()))
-        //    {
-        //        var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://localhost");
-        //        var httpResponseMessage = new HttpResponseMessage();
-        //        this.testHttpMessageHandler.AddResponseMapping(httpRequestMessage.RequestUri.ToString(), httpResponseMessage);
-
-        //        var returnedResponseMessage = await myHttpProvider.SendAsync(httpRequestMessage);
-
-        //        Assert.Equal(httpResponseMessage, returnedResponseMessage);
-        //        Assert.NotNull(returnedResponseMessage.RequestMessage.Headers.Authorization);
-        //        Assert.Equal(expectedToken, returnedResponseMessage.RequestMessage.Headers.Authorization.Parameter);
-        //    }
-        //}
     }
 }

--- a/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Core.Test/Requests/Middleware/AuthenticationHandlerTests.cs
@@ -251,7 +251,7 @@ namespace Microsoft.Graph.DotnetCore.Core.Test.Requests
             Assert.Equal(response.RequestMessage.Content.ReadAsStringAsync().Result, "Hello Mars!");
         }
 
-        [Fact]
+        [Fact(Skip = "In order to support HttpProvider, we'll skip authentication if no provider is set. We will add enable this once we re-write a new HttpProvider.")]
         public async Task AuthHandler_ShouldThrowExceptionWhenAuthProviderIsNotSet()
         {
             DelegatingHandler authHandler = new AuthenticationHandler(null, testHttpMessageHandler);


### PR DESCRIPTION
Fixes #
- Fixes #449. 
  - Move static `HttpMessageHandler` and `Proxy` properties to `GraphClientFactory.Create` method as parameters.
- Fixes #447. 
  - Override the default pipeline when a HttpMessageHandler is set on the HttpProvider.
  - Remove null check on `AuthenticationHandler` since auth provider is optional when using `HttpProvider`.
  - `BaseRequest` checks HttpClient for authHandler feature flag when using our `HttpProvider` before authenticating request.
  - Add duplicate `httpMessageHandler` type check when creating a pipeline.
- Fixes #413.
  - Drain HttpResponses if they have a response body before redirecting/retrying to avoid blocking subsequent requests.
- Fixes #435.
  - Rewind content streams before reading stream content.