### PR TITLE
Keep stream open after disposing StreamWriter.

### DIFF
--- a/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
+++ b/src/Microsoft.Graph.Core/Requests/Content/BatchRequestContent.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Graph
 
         protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
         {
-            using (StreamWriter streamWritter = new StreamWriter(stream))
+            using (StreamWriter streamWritter = new StreamWriter(stream, new UTF8Encoding(), 1024, true))
             using (JsonTextWriter textWritter = new JsonTextWriter(streamWritter))
             {
                 JObject batchContent = await GetBatchRequestContentAsync();


### PR DESCRIPTION
Fixes #470 .

### Changes proposed in this pull request
- Leave stream open after disposing `StreamWriter` object.

NOTE:
- This only affects NetCore 2.1 and above.