### PR TITLE
Avoid extra memory allocation when doing chunked upload for large file

### DIFF
--- a/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
+++ b/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
@@ -125,7 +125,6 @@ namespace Microsoft.Graph
         public async Task<DriveItem> UploadAsync(int maxTries = 3, IEnumerable<Option> options = null)
         {
             var uploadTries = 0;
-            var readBuffer = new byte[this.maxChunkSize];
             var trackedExceptions = new List<Exception>();
 
             while (uploadTries < maxTries)
@@ -134,7 +133,7 @@ namespace Microsoft.Graph
 
                 foreach (var request in chunkRequests)
                 {
-                    var result = await this.GetChunkRequestResponseAsync(request, readBuffer, trackedExceptions).ConfigureAwait(false);
+                    var result = await this.GetChunkRequestResponseAsync(request, trackedExceptions).ConfigureAwait(false);
 
                     if (result.UploadSucceeded)
                     {
@@ -158,22 +157,17 @@ namespace Microsoft.Graph
         /// Write a chunk of data using the UploadChunkRequest.
         /// </summary>
         /// <param name="request">The UploadChunkRequest to make the request with.</param>
-        /// <param name="readBuffer">The byte[] content to read from.</param>
         /// <param name="exceptionTrackingList">A list of exceptions to use to track progress. ChunkedUpload may retry.</param>
         /// <returns></returns>
-        public virtual async Task<UploadChunkResult> GetChunkRequestResponseAsync(UploadChunkRequest request, byte[] readBuffer, ICollection<Exception> exceptionTrackingList)
+        public virtual async Task<UploadChunkResult> GetChunkRequestResponseAsync(UploadChunkRequest request, ICollection<Exception> exceptionTrackingList)
         {
             var firstAttempt = true;
             this.uploadStream.Seek(request.RangeBegin, SeekOrigin.Begin);
-            await this.uploadStream.ReadAsync(readBuffer, 0, request.RangeLength).ConfigureAwait(false);
 
             while (true)
             {
-                using (var requestBodyStream = new MemoryStream(request.RangeLength))
+                using (var requestBodyStream = new ReadOnlySubStream(this.uploadStream,request.RangeBegin,request.RangeLength))
                 {
-                    await requestBodyStream.WriteAsync(readBuffer, 0, request.RangeLength).ConfigureAwait(false);
-                    requestBodyStream.Seek(0, SeekOrigin.Begin);
-
                     try
                     {
                         return await request.PutAsync(requestBodyStream).ConfigureAwait(false);

--- a/src/Microsoft.Graph/Requests/Helpers/ReadOnlySubStream.cs
+++ b/src/Microsoft.Graph/Requests/Helpers/ReadOnlySubStream.cs
@@ -1,0 +1,132 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ---------------
+
+namespace Microsoft.Graph
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+
+    internal class ReadOnlySubStream:Stream
+    {
+        private readonly long startInSuperStream;
+        private long positionInSuperStream;
+        private readonly long endInSuperStream;
+        private readonly Stream superStream;
+        private bool canRead;
+        private bool isDisposed;
+
+        public ReadOnlySubStream(Stream superStream, long startPosition, long maxLength)
+        {
+            this.startInSuperStream = startPosition;
+            this.positionInSuperStream = startPosition;
+            this.endInSuperStream = startPosition + maxLength;
+            this.superStream = superStream;
+            this.canRead = true;
+            this.isDisposed = false;
+        }
+
+        public override long Length
+        {
+            get
+            {
+                ThrowIfDisposed();
+
+                return endInSuperStream - startInSuperStream;
+            }
+        }
+
+        public override long Position
+        {
+            get
+            {
+                ThrowIfDisposed();
+
+                return positionInSuperStream - startInSuperStream;
+            }
+            set
+            {
+                ThrowIfDisposed();
+
+                throw new NotSupportedException("seek not support");
+            }
+        }
+
+        public override bool CanRead => superStream.CanRead && canRead;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => false;
+
+        private void ThrowIfDisposed()
+        {
+            if (isDisposed)
+                throw new ObjectDisposedException(GetType().ToString(), nameof(this.superStream));
+        }
+
+        private void ThrowIfCantRead()
+        {
+            if (!CanRead)
+                throw new NotSupportedException("read not support");
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            // parameter validation sent to _superStream.Read
+            int origCount = count;
+
+            ThrowIfDisposed();
+            ThrowIfCantRead();
+
+            if (superStream.Position != positionInSuperStream)
+                superStream.Seek(positionInSuperStream, SeekOrigin.Begin);
+            if (positionInSuperStream + count > endInSuperStream)
+                count = (int)(endInSuperStream - positionInSuperStream);
+
+            Debug.Assert(count >= 0);
+            Debug.Assert(count <= origCount);
+
+            int ret = superStream.Read(buffer, offset, count);
+
+            positionInSuperStream += ret;
+            return ret;
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            ThrowIfDisposed();
+            throw new NotSupportedException("seek not support");
+        }
+
+        public override void SetLength(long value)
+        {
+            ThrowIfDisposed();
+            throw new NotSupportedException("seek and write not support");
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            ThrowIfDisposed();
+            throw new NotSupportedException("write not support");
+        }
+
+        public override void Flush()
+        {
+            ThrowIfDisposed();
+            throw new NotSupportedException("write not support");
+        }
+
+        // Close the stream for reading.  Note that this does NOT close the superStream (since
+        // the substream is just 'a chunk' of the super-stream
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !isDisposed)
+            {
+                canRead = false;
+                isDisposed = true;
+            }
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/OneDriveTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/OneDriveTests.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
 
                     // Setup the chunk request necessities
                     var chunkRequests = provider.GetUploadChunkRequests();
-                    var readBuffer = new byte[maxChunkSize];
                     var trackedExceptions = new List<Exception>();
                     DriveItem itemResult = null;
 
@@ -71,7 +70,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
                         // Do your updates here: update progress bar, etc.
                         // ...
                         // Send chunk request
-                        var result = await provider.GetChunkRequestResponseAsync(request, readBuffer, trackedExceptions);
+                        var result = await provider.GetChunkRequestResponseAsync(request, trackedExceptions);
 
                         if (result.UploadSucceeded)
                         {


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->


<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
-  Avoid extra memory allocation when doing chunked upload
ChunkedUploadProvider trys to help with large file uploading, it divides the large stream to chunk-size stream and upload each one by one. The current implementation allocate maxChunksize of byte[] buffer each time:
```c#
  var readBuffer = new byte[this.maxChunkSize]; // extra allocation
```
and an extra stream copy:

```c#
    //extra copy 
    await this.uploadStream.ReadAsync(readBuffer, 0, request.RangeLength).ConfigureAwait(false);

       while (true)
       {
             using (var requestBodyStream = new MemoryStream(request.RangeLength))
             {
                 await requestBodyStream.WriteAsync(readBuffer, 0, request.RangeLength).ConfigureAwait(false);
                 requestBodyStream.Seek(0, SeekOrigin.Begin);
                 ...
             }
       }
```
If there is a total 500MiB size file, open a FileStream with a 10MiB max chunk size, it will allocate a 10 * 1024 * 1024 size buffer 50 times (extra 500MiB memory allocation), and do 100 times buffer operations (50 read and 50 write).

Because the upload stream supports seek and read operation, this pull request provide a ReadOnlySubStream to represent a chunk of a upload stream to save memory when dealing with large file and remove the extra copy operations