### PR TITLE
Feature/date timezone extensions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ branches:
   only:
   - dev
   - master
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 before_build:
 - cmd: >-

--- a/src/Microsoft.Graph/Models/Extensions/DateTimeZoneExtensions.cs
+++ b/src/Microsoft.Graph/Models/Extensions/DateTimeZoneExtensions.cs
@@ -96,6 +96,56 @@ namespace Microsoft.Graph.Extensions
 
             return new DateTimeOffset(dateTime, offset);
         }
+        /// <summary>
+        /// Converts the dateTime to a DateTimeTimeZone object
+        /// <para>This method assumes the value is expressed on the same timezone as the target mailbox and the local machine</para>
+        /// </summary>
+        /// <param name="dateTime">>A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
+        /// <returns></returns>
+        public static DateTimeTimeZone ToDateTimeTimeZone(this DateTime dateTime)
+        {
+            return DateTimeTimeZone.FromDateTime(dateTime);
+        }
+        /// <summary>
+        /// Converts the dateTime to a DateTimeTimeZone object
+        /// </summary>
+        /// <param name="dateTime">>A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
+        /// <param name="timeZoneInfo">The expected values for timeZone are specified here: https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0 </param>
+        /// <returns></returns>
+        public static DateTimeTimeZone ToDateTimeTimeZone(this DateTime dateTime, TimeZoneInfo timeZoneInfo)
+        {
+            return DateTimeTimeZone.FromDateTime(dateTime, timeZoneInfo);
+        }
+        /// <summary>
+        /// Converts the dateTimeOffset to a DateTimeTimeZone object
+        /// <para>This method assumes the value is expressed on the same timezone as the target mailbox and the local machine</para>
+        /// </summary>
+        /// <param name="dateTimeOffset">>A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
+        /// <returns></returns>
+        public static DateTimeTimeZone ToDateTimeTimeZone(this DateTimeOffset dateTimeOffset)
+        {
+            return DateTimeTimeZone.FromDateTimeOffset(dateTimeOffset);
+        }
+        /// <summary>
+        /// Converts the dateTimeOffset to a DateTimeTimeZone object
+        /// </summary>
+        /// <param name="dateTimeOffset">>A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
+        /// <param name="timeZone">The expected values for timeZone are specified here: https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0 </param>
+        /// <returns></returns>
+        public static DateTimeTimeZone ToDateTimeTimeZone(this DateTimeOffset dateTimeOffset, string timeZone)
+        {
+            return DateTimeTimeZone.FromDateTimeOffset(dateTimeOffset, timeZone);
+        }
+        /// <summary>
+        /// Converts the dateTimeOffset to a DateTimeTimeZone object
+        /// </summary>
+        /// <param name="dateTimeOffset">>A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
+        /// <param name="timeZoneInfo">The expected values for timeZone are specified here: https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0 </param>
+        /// <returns></returns>
+        public static DateTimeTimeZone ToDateTimeTimeZone(this DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
+        {
+            return DateTimeTimeZone.FromDateTimeOffset(dateTimeOffset, timeZoneInfo);
+        }
     }
 }
 
@@ -107,6 +157,7 @@ namespace Microsoft.Graph
 
         /// <summary>
         /// Converts a Datetime parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone
+        /// <para>This method assumes the value is expressed on the same timezone as the target mailbox and the local machine</para>
         /// </summary>
         /// <param name="dateTime">A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
         /// <returns></returns>
@@ -115,7 +166,7 @@ namespace Microsoft.Graph
             DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
             {
                 DateTime = dateTime.ToString(DateTimeFormat, CultureInfo.InvariantCulture),
-                TimeZone = ""
+                TimeZone = string.Empty
             };
 
             return dateTimeTimeZone;
@@ -139,6 +190,39 @@ namespace Microsoft.Graph
         }
 
         /// <summary>
+        /// Converts a Datetime parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone
+        /// </summary>
+        /// <param name="dateTime">A single point of time in a combined date and time representation ({date}T{time}; for example, 2017-08-29T04:00:00.0000000).</param>
+        /// <param name="timeZoneInfo">The expected values for timeZone are specified here: https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0 </param>
+        /// <returns></returns>
+        public static DateTimeTimeZone FromDateTime(DateTime dateTime, TimeZoneInfo timeZoneInfo)
+        {
+            DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
+            {
+                DateTime = dateTime.ToString(DateTimeFormat, CultureInfo.InvariantCulture),
+                TimeZone = timeZoneInfo.Id
+            };
+            return dateTimeTimeZone;
+        }
+
+        /// <summary>
+        /// Converts a DatetimeOffset parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone
+        /// <para>This method assumes the value is expressed on the same timezone as the target mailbox and the local machine</para>
+        /// </summary>
+        /// <param name="dateTimeOffset">Represents a point in time, typically expressed as a date and time of day, relative to Coordinated Universal Time (UTC).</param>
+        /// <returns></returns>
+        public static DateTimeTimeZone FromDateTimeOffset(DateTimeOffset dateTimeOffset)
+        {
+            DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
+            {
+                DateTime = dateTimeOffset.ToString(DateTimeFormat, CultureInfo.InvariantCulture),
+                TimeZone = string.Empty
+            };
+
+            return dateTimeTimeZone;
+        }
+
+        /// <summary>
         /// Converts a DatetimeOffset parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone
         /// </summary>
         /// <param name="dateTimeOffset">Represents a point in time, typically expressed as a date and time of day, relative to Coordinated Universal Time (UTC).</param>
@@ -150,6 +234,23 @@ namespace Microsoft.Graph
             {
                 DateTime = dateTimeOffset.ToString(DateTimeFormat, CultureInfo.InvariantCulture),
                 TimeZone = timeZone
+            };
+
+            return dateTimeTimeZone;
+        }
+
+        /// <summary>
+        /// Converts a DatetimeOffset parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone
+        /// </summary>
+        /// <param name="dateTimeOffset">Represents a point in time, typically expressed as a date and time of day, relative to Coordinated Universal Time (UTC).</param>
+        /// <param name="timeZoneInfo">The expected values for timeZone are specified here: https://docs.microsoft.com/en-us/graph/api/resources/datetimetimezone?view=graph-rest-1.0 </param>
+        /// <returns></returns>
+        public static DateTimeTimeZone FromDateTimeOffset(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
+        {
+            DateTimeTimeZone dateTimeTimeZone = new DateTimeTimeZone
+            {
+                DateTime = dateTimeOffset.ToString(DateTimeFormat, CultureInfo.InvariantCulture),
+                TimeZone = timeZoneInfo.Id
             };
 
             return dateTimeTimeZone;

--- a/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
@@ -1,13 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AssemblyName>Microsoft.Graph.DotnetCore.Test</AssemblyName>
     <PackageId>Microsoft.Graph.DotnetCore.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <NetStandardImplicitPackageVersion>1.6.0</NetStandardImplicitPackageVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
@@ -19,10 +17,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.10.1" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="Moq" Version="4.13.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   
   <ItemGroup>

--- a/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Microsoft.Graph.DotnetCore.Test.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>Microsoft.Graph.DotnetCore.Test</AssemblyName>
     <PackageId>Microsoft.Graph.DotnetCore.Test</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/tests/Microsoft.Graph.DotnetCore.Test/Models/Extensions/DateTimeZoneExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Models/Extensions/DateTimeZoneExtensionsTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Extensions
 
             var actualDateTime = dateTimeTimeZone.ToDateTime();
             var expectedDateTime = DateTime.ParseExact(dateTimeTimeZone.DateTime, DateTimeFormat, CultureInfo.InvariantCulture);
-                                 
+
             Assert.Equal(expectedDateTime, actualDateTime);
         }
 
@@ -88,7 +88,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Extensions
                 DateTime = "2019-06-03T22:00:00.0000000"
             };
             dateTimeTimeZoneList.Add(dateTimeTimeZoneTestThree);
-            
+
             foreach (var dateTimeTimeZone in dateTimeTimeZoneList)
             {
                 DateTime dateTime = GetDateTimeFromDateTimeTimeZone(dateTimeTimeZone);
@@ -103,6 +103,48 @@ namespace Microsoft.Graph.DotnetCore.Test.Extensions
 
                 Assert.Equal(expectedDateTimeOffset.ToString(DateTimeFormat, CultureInfo.InvariantCulture), actualDateTimeTimeZone.DateTime);
                 Assert.Equal(timeZoneInfo.Id, actualDateTimeTimeZone.TimeZone);
+            }
+        }
+
+        [Fact]
+        public void FromDateTimeOffset_Should_Convert_DateTimeOffset_To_DateTimeTimeZone_DefaultParameter()
+        {
+            List<DateTimeTimeZone> dateTimeTimeZoneList = new List<DateTimeTimeZone>();
+            DateTimeTimeZone dateTimeTimeZoneTestOne = new DateTimeTimeZone
+            {
+                TimeZone = "Eastern Standard Time",
+                DateTime = "2019-06-03T14:00:00.0000000"
+            };
+            dateTimeTimeZoneList.Add(dateTimeTimeZoneTestOne);
+
+            DateTimeTimeZone dateTimeTimeZoneTestTwo = new DateTimeTimeZone
+            {
+                TimeZone = "UTC",
+                DateTime = "2019-01-25T06:37:39.8058788Z"
+            };
+            dateTimeTimeZoneList.Add(dateTimeTimeZoneTestTwo);
+
+            DateTimeTimeZone dateTimeTimeZoneTestThree = new DateTimeTimeZone
+            {
+                TimeZone = "Mauritius Standard Time",
+                DateTime = "2019-06-03T22:00:00.0000000"
+            };
+            dateTimeTimeZoneList.Add(dateTimeTimeZoneTestThree);
+
+            foreach (var dateTimeTimeZone in dateTimeTimeZoneList)
+            {
+                DateTime dateTime = GetDateTimeFromDateTimeTimeZone(dateTimeTimeZone);
+                TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(dateTimeTimeZone.TimeZone);
+
+                TimeSpan offset = timeZoneInfo.GetUtcOffset(dateTime);
+                dateTime = DateTime.SpecifyKind(dateTime, DateTimeKind.Unspecified);
+
+                var expectedDateTimeOffset = new DateTimeOffset(dateTime, offset);
+                expectedDateTimeOffset = TimeZoneInfo.ConvertTime(expectedDateTimeOffset, timeZoneInfo);
+                var actualDateTimeTimeZone = DateTimeTimeZone.FromDateTimeOffset(expectedDateTimeOffset);
+
+                Assert.Equal(expectedDateTimeOffset.ToString(DateTimeFormat, CultureInfo.InvariantCulture), actualDateTimeTimeZone.DateTime);
+                Assert.Empty(actualDateTimeTimeZone.TimeZone);
             }
         }
 

--- a/tests/Microsoft.Graph.DotnetCore.Test/Models/Generated/EntityTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Models/Generated/EntityTests.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Models.Generated
             var constructors = entityType.GetConstructors(
                 BindingFlags.Public | BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Instance);
 
-            Assert.Equal(1, constructors.Count());
+            Assert.Single(constructors);
 
             var defaultConstructor = constructors.First();
             Assert.False(defaultConstructor.IsPrivate);


### PR DESCRIPTION
Fixes #366 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Upgraded unit test project to dotnetcore2.2 and upgraded dependencies of the test project
- DateTime.ToDateTimeTimeZone()
- DateTime.ToDateTimeTimeZone(TimeZoneInfo timeZoneInfo)
- DateTimeOffset.ToDateTimeTimeZone()
- DateTimeOffset.ToDateTimeTimeZone(string timeZone)
- DateTimeOffset.ToDateTimeTimeZone(TimeZoneInfo timeZoneInfo)
- DateTimeTimeZone.FromDateTime(DateTime dateTime, TimeZoneInfo timeZoneInfo)
- DateTimeTimeZone.FromDateTimeOffset(DateTimeOffset dateTimeOffset, TimeZoneInfo timeZoneInfo)
- DateTimeTimeZone.FromDateTimeOffset(DateTimeOffset dateTimeOffset)