### PR TITLE
Bearer in Auth header needs to be capitalized (at least for proxy)

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -36,7 +36,7 @@ The `DelegateAuthenticationProvider` is an implementation of `IAuthenticationPro
 var graphServiceClient = new GraphServiceClient(new DelegateAuthenticationProvider((requestMessage) => {
     requestMessage
         .Headers
-        .Authorization = new AuthenticationHeaderValue("bearer", accessToken);
+        .Authorization = new AuthenticationHeaderValue("Bearer", accessToken);
 
     return Task.FromResult(0);
 }));


### PR DESCRIPTION
Was using delegate provider example to setup a new sample/mock provider for the [new XAML controls](https://aka.ms/wgt), but was having an auth problem.  Looks like the proxy expects a capital `B` which seems to be what I see in most examples.  Figured would be good to at least update the example for now until the proxy can be fixed to ignore case.