### PR TITLE
Fix for improper path encoding

### DIFF
--- a/src/Microsoft.Graph/Requests/Extensions/DriveItemRequestBuilderExtensions.cs
+++ b/src/Microsoft.Graph/Requests/Extensions/DriveItemRequestBuilderExtensions.cs
@@ -4,6 +4,8 @@
 
 namespace Microsoft.Graph
 {
+    using System;
+
     /// <summary>
     /// The type  DriveItemRequestBuilder.
     /// </summary>
@@ -23,8 +25,13 @@ namespace Microsoft.Graph
                 }
             }
 
+            // Encode the path in accordance with the one drive spec 
+            // https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/addressing-driveitems
+            UriBuilder builder = new UriBuilder(this.RequestUrl);
+            builder.Path += string.Format(":{0}:", path);
+
             return new DriveItemRequestBuilder(
-                string.Format("{0}:{1}:", this.RequestUrl, path),
+                builder.Uri.OriginalString,
                 this.Client);
         }
     }

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Extensions/DriveItemRequestBuilderExtensionsTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Extensions/DriveItemRequestBuilderExtensionsTests.cs
@@ -50,5 +50,28 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Extensions
             Assert.NotNull(itemRequest);
             Assert.Equal(expectedRequestUri, new Uri(itemRequest.RequestUrl));
         }
+
+
+        // These tests are from the OneDrive docs found here to verify correct functionality
+        // https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/addressing-driveitems?view=odsp-graph-online#examples-1
+        [Theory]
+        [InlineData("Test#1.txt", "Test%231.txt")]
+        [InlineData("Ryan's Files", "Ryan's%20Files")]
+        [InlineData("doc (1).docx", "doc%20(1).docx")]
+        [InlineData("estimate%s.docx", "estimate%25s.docx")]
+        [InlineData("Break#Out", "Break%23Out")]
+        [InlineData("saved_game[1].bin", "saved_game[1].bin")]
+        public void ItemByPath_BuildRequestWithSpecialPoundCharacter(string pathInput, string expectedEncodedPath)
+        {
+            var expectedRequestUri = new Uri(string.Format(Constants.Url.GraphBaseUrlFormatString, "v1.0") + "/me/drive/root:/" + expectedEncodedPath + ":");
+            var itemRequestBuilder = this.graphServiceClient.Me.Drive.Root.ItemWithPath(pathInput) as DriveItemRequestBuilder;
+
+            Assert.NotNull(itemRequestBuilder);
+            Assert.Equal(expectedRequestUri, new Uri(itemRequestBuilder.RequestUrl));
+
+            var itemRequest = itemRequestBuilder.Request() as DriveItemRequest;
+            Assert.NotNull(itemRequest);
+            Assert.Equal(expectedRequestUri, new Uri(itemRequest.RequestUrl));
+        }
     }
 }


### PR DESCRIPTION
Fixes #553

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Encode the path segment of the URI to ensure special characters are sorted out in accordance with the one drive expectations
- Adds tests to verify the URL

Therefore making a call in the code as follows should now **NOT** fail with an error.

```cs
var session = await client.Drives[DriveId].Root.ItemWithPath("Test#1.txt").CreateUploadSession().Request().PostAsync();
```
<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/addressing-driveitems?view=odsp-graph-online
- https://docs.microsoft.com/en-us/onedrive/developer/rest-api/concepts/addressing-driveitems?view=odsp-graph-online#net--c-sharp--visual-basic