### PR TITLE
Updated readme to link post describing version bump, updated targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Integrate the [Microsoft Graph API](https://graph.microsoft.io) into your .NET
 project!
 
-The Microsoft Graph .NET Client Library targets .NetStandard 1.1 and .Net Framework 4.5.
+The Microsoft Graph .NET Client Library targets .NetStandard 2.0 and .Net Framework 4.6.1.
 
 ## Installation via NuGet
 
@@ -85,6 +85,7 @@ The following sample applications are also available:
 * [Headers](docs/headers.md)
 * [Microsoft Graph API](https://graph.microsoft.io)
 * [Release notes](https://github.com/microsoftgraph/msgraph-sdk-dotnet/releases)
+* [Blog - Microsoft Graph .NET SDK updates 3/16/20](https://developer.microsoft.com/en-us/graph/blogs/microsoft-graph-net-sdk-updates/)
 
 ## Notes
 


### PR DESCRIPTION
### Changes proposed in this pull request
No code changes - simply updated the README to include link to the blog post illustrating the need for the recent version bump for easier discovery and to reflect the change to the project targets (e.g. .NET Standard 1.6 to 2.0 and .NET Framework 4.5 to 4.6.1).

I'd suggested making this change in a recent [issue](https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/631), but it occurred to me I could make the change and offer it up myself.