### PR TITLE
Update GeneratedErrorConstants.cs

### DIFF
--- a/src/Microsoft.Graph/Exceptions/GeneratedErrorConstants.cs
+++ b/src/Microsoft.Graph/Exceptions/GeneratedErrorConstants.cs
@@ -4,16 +4,16 @@
 
 namespace Microsoft.Graph
 {
-    internal static class GeneratedErrorConstants
+    public static class GeneratedErrorConstants
     {
-        internal static class Codes
+        public static class Codes
         {
-            internal static string NotAllowed = "notAllowed";
+            public static string NotAllowed = "notAllowed";
         }
 
-        internal static class Messages
+        public static class Messages
         {
-            internal static string ResponseObjectUsedForUpdate = "Do not use objects returned in a response for updating an object in Microsoft Graph. " +
+            public static string ResponseObjectUsedForUpdate = "Do not use objects returned in a response for updating an object in Microsoft Graph. " +
                                                                  "Create a new {0} object and only set the updated properties on it.";
         }
     }


### PR DESCRIPTION
### Changes proposed in this pull request
- Let users to reference error codes rather than enforcing them to duplicate & be always in sync with errors code from graph lib.