### PR TITLE
Add delegate to PageIterator to allow consumers to configure next page request

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+# To learn more about .editorconfig see https://aka.ms/editorconfigdocs
+
+# All files
+[*]
+indent_style = space
+indent_size = 4

--- a/Microsoft.Graph.sln
+++ b/Microsoft.Graph.sln
@@ -10,6 +10,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Graph", "src\Micr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Graph.DotnetCore.Test", "tests\Microsoft.Graph.DotnetCore.Test\Microsoft.Graph.DotnetCore.Test.csproj", "{A46FC884-EDDC-4617-9B52-37017A90241D}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{483C32A2-1573-4E4D-9DE9-39C4CEAAA29C}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -19,7 +19,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>3.20.0</VersionPrefix>
+    <VersionPrefix>3.21.0</VersionPrefix>
     <!-- VersionPrefix minor version should not be set when the change comes from the generator. It will be updated automatically. -->
     <!-- VersionPrefix minor version must be manually set when making manual changes to code. -->
     <!-- VersionPrefix major and patch versions must be manually set. -->

--- a/src/Microsoft.Graph/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph/Tasks/PageIterator.cs
@@ -43,8 +43,9 @@ namespace Microsoft.Graph
         /// <param name="client">The GraphServiceClient object used to create the NextPageRequest for a delta query.</param>
         /// <param name="page">A generated implementation of ICollectionPage.</param>
         /// <param name="callback">A Func delegate that processes type TEntity in the result set and should return false if the iterator should cancel processing.</param>
+        /// <param name="requestConfigurator">A Func delegate that configures the NextPageRequest</param>
         /// <returns>A PageIterator&lt;TEntity&gt; that will process additional result pages based on the rules specified in Func&lt;TEntity,bool&gt; processPageItems</returns>
-        public static PageIterator<TEntity> CreatePageIterator(IBaseClient client, ICollectionPage<TEntity> page, Func<TEntity, bool> callback)
+        public static PageIterator<TEntity> CreatePageIterator(IBaseClient client, ICollectionPage<TEntity> page, Func<TEntity, bool> callback, Func<IBaseRequest, IBaseRequest> requestConfigurator = null)
         {
             if (page == null)
                 throw new ArgumentNullException("page");
@@ -58,23 +59,9 @@ namespace Microsoft.Graph
                 _currentPage = page,
                 _pageItemQueue = new Queue<TEntity>(page),
                 _processPageItemCallback = callback,
+                _requestConfigurator = requestConfigurator,
                 State = PagingState.NotStarted
             };
-        }
-
-        /// <summary>
-        /// Creates the PageIterator with the results of an initial paged request. 
-        /// </summary>
-        /// <param name="client">The GraphServiceClient object used to create the NextPageRequest for a delta query.</param>
-        /// <param name="page">A generated implementation of ICollectionPage.</param>
-        /// <param name="callback">A Func delegate that processes type TEntity in the result set and should return false if the iterator should cancel processing.</param>
-        /// <param name="requestConfigurator">A Func delegate that configures the NextPageRequest</param>
-        /// <returns>A PageIterator&lt;TEntity&gt; that will process additional result pages based on the rules specified in Func&lt;TEntity,bool&gt; processPageItems</returns>
-        public static PageIterator<TEntity> CreatePageIterator(IBaseClient client, ICollectionPage<TEntity> page, Func<TEntity, bool> callback, Func<IBaseRequest, IBaseRequest> requestConfigurator = null)
-        {
-            var iterator = CreatePageIterator(client, page, callback);
-            iterator._requestConfigurator = requestConfigurator;
-            return iterator;
         }
 
         /// <summary>

--- a/src/Microsoft.Graph/Tasks/PageIterator.cs
+++ b/src/Microsoft.Graph/Tasks/PageIterator.cs
@@ -24,10 +24,10 @@ namespace Microsoft.Graph
         private Func<TEntity, bool> _processPageItemCallback;
         private Func<IBaseRequest, IBaseRequest> _requestConfigurator;
 
-    /// <summary>
-    /// The @odata.deltaLink returned from a delta query.
-    /// </summary>
-    public string Deltalink { get; private set; }
+        /// <summary>
+        /// The @odata.deltaLink returned from a delta query.
+        /// </summary>
+        public string Deltalink { get; private set; }
         /// <summary>
         /// The @odata.nextLink returned in a paged result.
         /// </summary>


### PR DESCRIPTION
Fixes #852

### Changes proposed in this pull request
- Add a delegate to PageIterator the allows consumers to configure the next page request ( `IBaseRequest` ) before it is invoked.
