### PR TITLE
Fix ToDateTimeOffset when DateTime has '+00:00' suffix

### DIFF
--- a/src/Microsoft.Graph/Models/Extensions/DateTimeZoneExtensions.cs
+++ b/src/Microsoft.Graph/Models/Extensions/DateTimeZoneExtensions.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Graph.Extensions
 
             DateTime dateTime = DateTime.ParseExact(dateTimeTimeZone.DateTime, DateTimeTimeZone.DateTimeFormat, CultureInfo.InvariantCulture);
             TimeZoneInfo timeZoneInfo = TimeZoneInfo.FindSystemTimeZoneById(dateTimeTimeZone.TimeZone);
-            return dateTime.ToDateTimeOffset(timeZoneInfo);
+            return TimeZoneInfo.ConvertTime(dateTime, timeZoneInfo);
         }
 
         internal static DateTimeOffset ToDateTimeOffset(this DateTime dateTime, TimeZoneInfo timeZoneInfo)
@@ -153,7 +153,7 @@ namespace Microsoft.Graph
 {
     public partial class DateTimeTimeZone
     {
-        internal const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffffK";
+        public const string DateTimeFormat = "yyyy-MM-ddTHH:mm:ss.fffffffK";
 
         /// <summary>
         /// Converts a Datetime parameter to its equivalent DateTimeTimeZone Complex Type given its TimeZone


### PR DESCRIPTION
This fixes incorrect parsing to DateTime when DateTime string ends with '+00:00' - then local server time is returned rather than time from graph api.

E.g.
![image](https://user-images.githubusercontent.com/9931428/102522806-013dd180-4097-11eb-8633-7f0d8310a174.png)
If you run:
```DateTime.ParseExact(graphEvent.Start.DateTime, DateTimeTimeZone.DateTimeFormat, System.Globalization.CultureInfo.InvariantCulture)``` on it, it will result with DateTime with `Kind=Local` - which is incorrect and later `ToDateTimeOffset` doesn't work either.

![image](https://user-images.githubusercontent.com/9931428/102523033-50840200-4097-11eb-9fd4-b8f58cf27523.png)

### Other links
- https://stackoverflow.com/questions/1756639/why-cant-datetime-parse-parse-utc-date