### PR TITLE
Update minimum netframework to v4.6.2 in feature/2.0

### DIFF
--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -4,7 +4,7 @@
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <AssemblyTitle>Microsoft Graph V1.0 Service Client Library</AssemblyTitle>
     <Authors>Microsoft</Authors>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <PreserveCompilationContext>false</PreserveCompilationContext>
     <AssemblyName>Microsoft.Graph</AssemblyName>
@@ -28,13 +28,17 @@
     <PackageReleaseNotes>
 - [Breaking change] Update Microsoft.Graph.Core to v2.0.0
 - [Breaking change] Replace Newtosoft.Json with System.Text.Json
+- Add request builder methods for GraphResponse
+- [Breaking change] Removed IGraphServiceClient interface
+- Added GraphServiceClient constructor that accepts TokenCredential instance
+- [Breaking change] Bump minimun .NetFramework version to 4.6.2 from 4.6.1
     </PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
     <DocumentationFile>bin\Release\Microsoft.Graph.xml</DocumentationFile>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
This PR is part of https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/219

This comes in as a new requirement as 4.6.1 is coming to EOL soon.

This PR updates the release notes in the csproj to capture recent updates to the branch