### PR TITLE
Improvements/Updates to the upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Between 1.x and 3.x there were some minor possibly breaking changes:
 Between 3.x and 4.x there were some major breaking changes:
 
  * .NET Standard minimum version bumped from `netStandard1.3` to `netstandard2.0`
- * .NET Framework minimum version bumped from `net45` to `net461`
+ * .NET Framework minimum version bumped from `net45` to `net462`
  * Replacing Newtosoft.Json with System.Text.Json
  * Upgrading Microsoft.Graph.Core dependency to version 2.0.0
 


### PR DESCRIPTION
This PR updates the upgrade guide to capture developments that include : 

- GraphServiceClient taking the TokenCredential directly in its constructor
- Minimum .netFramework version bump to 4.6.2
- Dropping of IGraphServiceClient interface
- Changing type of Method to enum
- Missing information in code examples in the guide.