### PR TITLE
Update Abstract types with a base type to use DerivedType Converter

### DIFF
--- a/src/Microsoft.Graph/Generated/model/AppleDeviceFeaturesConfigurationBase.cs
+++ b/src/Microsoft.Graph/Generated/model/AppleDeviceFeaturesConfigurationBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Apple Device Features Configuration Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AppleDeviceFeaturesConfigurationBase>))]
     public partial class AppleDeviceFeaturesConfigurationBase : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/Attachment.cs
+++ b/src/Microsoft.Graph/Generated/model/Attachment.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Attachment.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Attachment>))]
     public partial class Attachment : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/AuthenticationMethod.cs
+++ b/src/Microsoft.Graph/Generated/model/AuthenticationMethod.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Authentication Method.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AuthenticationMethod>))]
     public partial class AuthenticationMethod : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/AuthenticationMethodConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/AuthenticationMethodConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Authentication Method Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<AuthenticationMethodConfiguration>))]
     public partial class AuthenticationMethodConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/BaseItem.cs
+++ b/src/Microsoft.Graph/Generated/model/BaseItem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Base Item.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<BaseItem>))]
     public partial class BaseItem : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/BaseItemVersion.cs
+++ b/src/Microsoft.Graph/Generated/model/BaseItemVersion.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Base Item Version.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<BaseItemVersion>))]
     public partial class BaseItemVersion : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ChangeTrackedEntity.cs
+++ b/src/Microsoft.Graph/Generated/model/ChangeTrackedEntity.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Change Tracked Entity.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ChangeTrackedEntity>))]
     public partial class ChangeTrackedEntity : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ConversationMember.cs
+++ b/src/Microsoft.Graph/Generated/model/ConversationMember.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Conversation Member.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ConversationMember>))]
     public partial class ConversationMember : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceCompliancePolicy.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceCompliancePolicy.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Compliance Policy.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceCompliancePolicy>))]
     public partial class DeviceCompliancePolicy : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceConfiguration>))]
     public partial class DeviceConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/DeviceEnrollmentConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/DeviceEnrollmentConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Device Enrollment Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<DeviceEnrollmentConfiguration>))]
     public partial class DeviceEnrollmentConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/EducationOrganization.cs
+++ b/src/Microsoft.Graph/Generated/model/EducationOrganization.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Education Organization.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<EducationOrganization>))]
     public partial class EducationOrganization : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/Extension.cs
+++ b/src/Microsoft.Graph/Generated/model/Extension.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Extension.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Extension>))]
     public partial class Extension : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/IosCertificateProfile.cs
+++ b/src/Microsoft.Graph/Generated/model/IosCertificateProfile.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Ios Certificate Profile.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<IosCertificateProfile>))]
     public partial class IosCertificateProfile : DeviceConfiguration
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedApp.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedApp>))]
     public partial class ManagedApp : MobileApp
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppConfiguration>))]
     public partial class ManagedAppConfiguration : ManagedAppPolicy
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppPolicy.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppPolicy.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Policy.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppPolicy>))]
     public partial class ManagedAppPolicy : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppProtection.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppProtection.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Protection.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppProtection>))]
     public partial class ManagedAppProtection : ManagedAppPolicy
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppRegistration.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppRegistration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Registration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppRegistration>))]
     public partial class ManagedAppRegistration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedAppStatus.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedAppStatus.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed App Status.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedAppStatus>))]
     public partial class ManagedAppStatus : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedDeviceMobileAppConfiguration.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedDeviceMobileAppConfiguration.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed Device Mobile App Configuration.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedDeviceMobileAppConfiguration>))]
     public partial class ManagedDeviceMobileAppConfiguration : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedEBook.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedEBook.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed EBook.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedEBook>))]
     public partial class ManagedEBook : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ManagedMobileLobApp.cs
+++ b/src/Microsoft.Graph/Generated/model/ManagedMobileLobApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Managed Mobile Lob App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ManagedMobileLobApp>))]
     public partial class ManagedMobileLobApp : ManagedApp
     {
     

--- a/src/Microsoft.Graph/Generated/model/MobileApp.cs
+++ b/src/Microsoft.Graph/Generated/model/MobileApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Mobile App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MobileApp>))]
     public partial class MobileApp : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/MobileLobApp.cs
+++ b/src/Microsoft.Graph/Generated/model/MobileLobApp.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Mobile Lob App.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<MobileLobApp>))]
     public partial class MobileLobApp : MobileApp
     {
     

--- a/src/Microsoft.Graph/Generated/model/OnenoteEntityBaseModel.cs
+++ b/src/Microsoft.Graph/Generated/model/OnenoteEntityBaseModel.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Onenote Entity Base Model.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OnenoteEntityBaseModel>))]
     public partial class OnenoteEntityBaseModel : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/OnenoteEntityHierarchyModel.cs
+++ b/src/Microsoft.Graph/Generated/model/OnenoteEntityHierarchyModel.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Onenote Entity Hierarchy Model.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OnenoteEntityHierarchyModel>))]
     public partial class OnenoteEntityHierarchyModel : OnenoteEntitySchemaObjectModel
     {
     

--- a/src/Microsoft.Graph/Generated/model/OnenoteEntitySchemaObjectModel.cs
+++ b/src/Microsoft.Graph/Generated/model/OnenoteEntitySchemaObjectModel.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Onenote Entity Schema Object Model.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OnenoteEntitySchemaObjectModel>))]
     public partial class OnenoteEntitySchemaObjectModel : OnenoteEntityBaseModel
     {
     

--- a/src/Microsoft.Graph/Generated/model/OpenShiftChangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/model/OpenShiftChangeRequest.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Open Shift Change Request.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OpenShiftChangeRequestObject>))]
     public partial class OpenShiftChangeRequestObject : ScheduleChangeRequestObject
     {
     

--- a/src/Microsoft.Graph/Generated/model/OrganizationalBrandingProperties.cs
+++ b/src/Microsoft.Graph/Generated/model/OrganizationalBrandingProperties.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Organizational Branding Properties.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OrganizationalBrandingProperties>))]
     public partial class OrganizationalBrandingProperties : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/OutlookItem.cs
+++ b/src/Microsoft.Graph/Generated/model/OutlookItem.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Outlook Item.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<OutlookItem>))]
     public partial class OutlookItem : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/Place.cs
+++ b/src/Microsoft.Graph/Generated/model/Place.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Place.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<Place>))]
     public partial class Place : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/PolicyBase.cs
+++ b/src/Microsoft.Graph/Generated/model/PolicyBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Policy Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PolicyBase>))]
     public partial class PolicyBase : DirectoryObject
     {
     

--- a/src/Microsoft.Graph/Generated/model/PrintOperation.cs
+++ b/src/Microsoft.Graph/Generated/model/PrintOperation.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Print Operation.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PrintOperation>))]
     public partial class PrintOperation : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/PrintUsage.cs
+++ b/src/Microsoft.Graph/Generated/model/PrintUsage.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Print Usage.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PrintUsage>))]
     public partial class PrintUsage : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/PrinterBase.cs
+++ b/src/Microsoft.Graph/Generated/model/PrinterBase.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Printer Base.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<PrinterBase>))]
     public partial class PrinterBase : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/ScheduleChangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/model/ScheduleChangeRequest.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Schedule Change Request.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ScheduleChangeRequestObject>))]
     public partial class ScheduleChangeRequestObject : ChangeTrackedEntity
     {
     

--- a/src/Microsoft.Graph/Generated/model/StsPolicy.cs
+++ b/src/Microsoft.Graph/Generated/model/StsPolicy.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Sts Policy.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<StsPolicy>))]
     public partial class StsPolicy : PolicyBase
     {
     

--- a/src/Microsoft.Graph/Generated/model/TargetedManagedAppProtection.cs
+++ b/src/Microsoft.Graph/Generated/model/TargetedManagedAppProtection.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Targeted Managed App Protection.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<TargetedManagedAppProtection>))]
     public partial class TargetedManagedAppProtection : ManagedAppProtection
     {
     

--- a/src/Microsoft.Graph/Generated/model/ThreatAssessmentRequest.cs
+++ b/src/Microsoft.Graph/Generated/model/ThreatAssessmentRequest.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Threat Assessment Request.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<ThreatAssessmentRequestObject>))]
     public partial class ThreatAssessmentRequestObject : Entity
     {
     

--- a/src/Microsoft.Graph/Generated/model/WindowsInformationProtection.cs
+++ b/src/Microsoft.Graph/Generated/model/WindowsInformationProtection.cs
@@ -17,6 +17,7 @@ namespace Microsoft.Graph
     /// <summary>
     /// The type Windows Information Protection.
     /// </summary>
+    [JsonConverter(typeof(DerivedTypeConverter<WindowsInformationProtection>))]
     public partial class WindowsInformationProtection : ManagedAppPolicy
     {
     

--- a/src/Microsoft.Graph/Generated/requests/ReportRootDeviceConfigurationDeviceActivityRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootDeviceConfigurationDeviceActivityRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootDeviceConfigurationUserActivityRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootDeviceConfigurationUserActivityRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailActivityUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageAppsUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageAppsUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageVersionsUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetEmailAppUsageVersionsUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageMailboxCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageMailboxCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageQuotaStatusMailboxCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageQuotaStatusMailboxCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageStorageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetMailboxUsageStorageRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationsUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationsUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationsUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActivationsUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActiveUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActiveUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActiveUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ActiveUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityFileCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityGroupCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityGroupCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityStorageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365GroupsActivityStorageRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ServicesUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOffice365ServicesUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityFileCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveActivityUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageAccountCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageAccountCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageAccountDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageAccountDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageFileCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageStorageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetOneDriveUsageStorageRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityFileCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityPagesRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityPagesRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointActivityUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageFileCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageFileCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsagePagesRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsagePagesRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageSiteCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageSiteCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageStorageRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSharePointSiteUsageStorageRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessActivityUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageDistributionUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageDistributionUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessDeviceUsageUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityMinuteCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityMinuteCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessOrganizerActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityMinuteCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityMinuteCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessParticipantActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityMinuteCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityMinuteCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetSkypeForBusinessPeerToPeerActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageDistributionUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageDistributionUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsDeviceUsageUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetTeamsUserActivityUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerActivityUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageDistributionUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageDistributionUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageUserCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageUserCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageUserDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerDeviceUsageUserDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityDetailRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityDetailRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityGroupCountsRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/ReportRootGetYammerGroupsActivityGroupCountsRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PatchAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PatchAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="report">The Report object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Report> PutAsync(Report report, 
+        public System.Threading.Tasks.Task<Report> PutAsync(Report report,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/SiteGetByPathRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/SiteGetByPathRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="site">The Site object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Site> PatchAsync(Site site, 
+        public System.Threading.Tasks.Task<Site> PatchAsync(Site site,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="site">The Site object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<Site> PutAsync(Site site, 
+        public System.Threading.Tasks.Task<Site> PutAsync(Site site,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchart">The WorkbookChart object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChart> PatchAsync(WorkbookChart workbookchart, 
+        public System.Threading.Tasks.Task<WorkbookChart> PatchAsync(WorkbookChart workbookchart,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchart">The WorkbookChart object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChart> PutAsync(WorkbookChart workbookchart, 
+        public System.Threading.Tasks.Task<WorkbookChart> PutAsync(WorkbookChart workbookchart,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartItemRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartItemRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchart">The WorkbookChart object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChart> PatchAsync(WorkbookChart workbookchart, 
+        public System.Threading.Tasks.Task<WorkbookChart> PatchAsync(WorkbookChart workbookchart,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchart">The WorkbookChart object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChart> PutAsync(WorkbookChart workbookchart, 
+        public System.Threading.Tasks.Task<WorkbookChart> PutAsync(WorkbookChart workbookchart,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartPointItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartPointItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchartpoint">The WorkbookChartPoint object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChartPoint> PatchAsync(WorkbookChartPoint workbookchartpoint, 
+        public System.Threading.Tasks.Task<WorkbookChartPoint> PatchAsync(WorkbookChartPoint workbookchartpoint,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchartpoint">The WorkbookChartPoint object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChartPoint> PutAsync(WorkbookChartPoint workbookchartpoint, 
+        public System.Threading.Tasks.Task<WorkbookChartPoint> PutAsync(WorkbookChartPoint workbookchartpoint,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookChartSeriesItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookChartSeriesItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchartseries">The WorkbookChartSeries object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChartSeries> PatchAsync(WorkbookChartSeries workbookchartseries, 
+        public System.Threading.Tasks.Task<WorkbookChartSeries> PatchAsync(WorkbookChartSeries workbookchartseries,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookchartseries">The WorkbookChartSeries object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookChartSeries> PutAsync(WorkbookChartSeries workbookchartseries, 
+        public System.Threading.Tasks.Task<WorkbookChartSeries> PutAsync(WorkbookChartSeries workbookchartseries,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookNamedItemRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookNamedItemRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeBorderItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeBorderItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeborder">The WorkbookRangeBorder object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeBorder> PatchAsync(WorkbookRangeBorder workbookrangeborder, 
+        public System.Threading.Tasks.Task<WorkbookRangeBorder> PatchAsync(WorkbookRangeBorder workbookrangeborder,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeborder">The WorkbookRangeBorder object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeBorder> PutAsync(WorkbookRangeBorder workbookrangeborder, 
+        public System.Threading.Tasks.Task<WorkbookRangeBorder> PutAsync(WorkbookRangeBorder workbookrangeborder,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeBoundingRectRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeBoundingRectRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeCellRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeCellRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnsAfterRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnsAfterRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnsBeforeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeColumnsBeforeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeEntireColumnRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeEntireColumnRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeEntireRowRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeEntireRowRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeIntersectionRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeIntersectionRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastCellRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastCellRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastColumnRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastColumnRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastRowRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeLastRowRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeOffsetRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeOffsetRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeResizedRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeResizedRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowsAboveRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowsAboveRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowsBelowRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeRowsBelowRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeUsedRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeUsedRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeViewItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeViewItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeview">The WorkbookRangeView object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeView> PatchAsync(WorkbookRangeView workbookrangeview, 
+        public System.Threading.Tasks.Task<WorkbookRangeView> PatchAsync(WorkbookRangeView workbookrangeview,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeview">The WorkbookRangeView object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeView> PutAsync(WorkbookRangeView workbookrangeview, 
+        public System.Threading.Tasks.Task<WorkbookRangeView> PutAsync(WorkbookRangeView workbookrangeview,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeViewRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeViewRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookRangeVisibleViewRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookRangeVisibleViewRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeview">The WorkbookRangeView object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeView> PatchAsync(WorkbookRangeView workbookrangeview, 
+        public System.Threading.Tasks.Task<WorkbookRangeView> PatchAsync(WorkbookRangeView workbookrangeview,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrangeview">The WorkbookRangeView object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRangeView> PutAsync(WorkbookRangeView workbookrangeview, 
+        public System.Threading.Tasks.Task<WorkbookRangeView> PutAsync(WorkbookRangeView workbookrangeview,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnDataBodyRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnDataBodyRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnHeaderRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnHeaderRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktablecolumn">The WorkbookTableColumn object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTableColumn> PatchAsync(WorkbookTableColumn workbooktablecolumn, 
+        public System.Threading.Tasks.Task<WorkbookTableColumn> PatchAsync(WorkbookTableColumn workbooktablecolumn,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktablecolumn">The WorkbookTableColumn object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTableColumn> PutAsync(WorkbookTableColumn workbooktablecolumn, 
+        public System.Threading.Tasks.Task<WorkbookTableColumn> PutAsync(WorkbookTableColumn workbooktablecolumn,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnTotalRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableColumnTotalRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableDataBodyRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableDataBodyRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableHeaderRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableHeaderRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktable">The WorkbookTable object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTable> PatchAsync(WorkbookTable workbooktable, 
+        public System.Threading.Tasks.Task<WorkbookTable> PatchAsync(WorkbookTable workbooktable,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktable">The WorkbookTable object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTable> PutAsync(WorkbookTable workbooktable, 
+        public System.Threading.Tasks.Task<WorkbookTable> PutAsync(WorkbookTable workbooktable,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableRowItemAtRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableRowItemAtRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktablerow">The WorkbookTableRow object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTableRow> PatchAsync(WorkbookTableRow workbooktablerow, 
+        public System.Threading.Tasks.Task<WorkbookTableRow> PatchAsync(WorkbookTableRow workbooktablerow,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbooktablerow">The WorkbookTableRow object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookTableRow> PutAsync(WorkbookTableRow workbooktablerow, 
+        public System.Threading.Tasks.Task<WorkbookTableRow> PutAsync(WorkbookTableRow workbooktablerow,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookTableTotalRowRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookTableTotalRowRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetCellRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetCellRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;

--- a/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetUsedRangeRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/WorkbookWorksheetUsedRangeRequest.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object set with the properties to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PatchAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PATCH;
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <param name="workbookrange">The WorkbookRange object to update.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> for the request.</param>
         /// <returns>The task to await for async call.</returns>
-        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange, 
+        public System.Threading.Tasks.Task<WorkbookRange> PutAsync(WorkbookRange workbookrange,
             CancellationToken cancellationToken = default(CancellationToken))
         {
             this.Method = HttpMethods.PUT;


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-beta-sdk-dotnet/issues/262

It fixes the issue where abstract types that have a base type not being annotated with the DeriveTypeConverter attribute.

This is a problem in System.Text.Json serialization as it causes derived types to be serialized only with the base type property as  System.Text.Json does not fully support polymorphic serialization like Newtonsoft.Json.
