### PR TITLE
Fixed For Api Change Where Search Parameter Required.

### DIFF
--- a/src/Microsoft.Graph/Generated/requests/GraphServiceSitesCollectionRequestBuilder.cs
+++ b/src/Microsoft.Graph/Generated/requests/GraphServiceSitesCollectionRequestBuilder.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="options">The query and header options for the request.</param>
         /// <returns>The built request.</returns>
-        public IGraphServiceSitesCollectionRequest Request(IEnumerable<Option> options)
+        public IGraphServiceSitesCollectionRequest Request(IEnumerable<Option> options=new Option[]{new QueryOption("search","*")})
         {
             return new GraphServiceSitesCollectionRequest(this.RequestUrl, this.Client, options);
         }


### PR DESCRIPTION
The get sites request is broken due to a API change that made it so the request to list all sites requires a search parameter.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/976)