### PR TITLE
Mark ChunkedUploadProvider as obsolete

### DIFF
--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -33,6 +33,7 @@
 - Added GraphServiceClient constructor that accepts TokenCredential instance
 - [Breaking change] Bump minimun .NetFramework version to 4.6.2 from 4.6.1
 - Publish symbols.
+- ChunkedUploadProvider marked as deprecated/obsolete
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
+++ b/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Graph
     /// to use small chunks if the connection is slow). Also allows the client to
     /// pause an upload and resume later.
     /// </summary>
+    [Obsolete("ChunkedUploadProvider is now deprecated. Please use the LargeFileUploadTask for the upload of large files using an UploadSession.")]
     public class ChunkedUploadProvider
     {
         private const int DefaultMaxChunkSize = 5 * 1024 * 1024;


### PR DESCRIPTION
These PR marks the ChunkedUploadProvider as obsolete so that intellisense can encourage SDK users to move to the LargeFileUploadTask.

Closes #980 

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1014)