### PR TITLE
Make properties of GraphServiceClient virtual (v1)

### DIFF
--- a/docs/tokencredentials.md
+++ b/docs/tokencredentials.md
@@ -67,13 +67,13 @@ This credential class provides a similar use to the [Client Credential Provider]
 The device code flow enables sign in to devices by way of another device.
 
 ```cs
-string[] scopes = {"User.Read"};
+string[] scopes = {"https://graph.microsoft.com/.default"};
 
 ClientSecretCredential clientSecretCredential = new ClientSecretCredential(tenantId, clientId, clientSecret); 
 
 GraphServiceClient graphServiceClient = new GraphServiceClient(clientSecretCredential, scopes);
 
-User me = await graphClient.Me.Request()
+User me = await graphClient.Users["user-id"].Request()
                 .GetAsync();
 ```
 
@@ -82,7 +82,7 @@ User me = await graphClient.Me.Request()
 This credential class provides a similar use to the [Client Credential Provider](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth#b-client-credential-provider) with the use of a client certificate and can be used as follows.
 
 ```cs
-string[] scopes = {"User.Read"};
+string[] scopes = {"https://graph.microsoft.com/.default"};
 
 ClientCertificateCredential clientCertificateCredential = new ClientCertificateCredential(tenantId, clientId, certificatePath);
 
@@ -91,7 +91,7 @@ ClientCertificateCredential clientCertificateCredential = new ClientCertificateC
 
 GraphServiceClient graphServiceClient = new GraphServiceClient(clientCertificateCredential, scopes);
 
-User me = await graphClient.Me.Request()
+User me = await graphClient.Users["user-id"].Request()
                 .GetAsync();
 ```
 

--- a/docs/upgrade-to-v4.md
+++ b/docs/upgrade-to-v4.md
@@ -210,6 +210,35 @@ Since the HTTP status code and response headers are now available through the Gr
 
 The `IGraphServiceClient` interface is not really an interface because it continues to change with metadata changes. This makes it not ideal to mock or inherit. The interface has therefore been removed and no longer exists.
 
+To alleviate challenges brought about by using mocking frameworks(such Moq), the properties/methods of the `GraphServiceClient` have been made virtual. 
+Therefore, one should be able to mock and mock and write tests in a fashion similar to the example below :-
+
+```cs
+// Arrange
+var mockAuthProvider = new Mock<IAuthenticationProvider>();
+var mockHttpProvider = new Mock<IHttpProvider>();
+var mockGraphClient = new Mock<GraphServiceClient>(mockAuthProvider.Object, mockHttpProvider.Object);
+
+ManagedDevice md = new ManagedDevice
+{
+    Id = "1",
+    DeviceCategory = new DeviceCategory()
+    {
+        Description = "Sample Description"
+    }
+};
+
+// setup the calls
+mockGraphClient.Setup(g => g.DeviceManagement.ManagedDevices["1"].Request().GetAsync(CancellationToken.None)).Returns(Task.Run(() => md)).Verifiable();
+
+// Act
+var graphClient = mockGraphClient.Object;
+var device = await graphClient.DeviceManagement.ManagedDevices["1"].Request().GetAsync(CancellationToken.None);
+
+// Assert
+Assert.Equal("1",device.Id);
+```
+
 ## Remarks about this guide
 
 This guide is written to be as exhaustive as possible, it is possible that we forgot to mention some breaking changes. If you experience breaking changes in your upgrade process that are not already listed in this guide, please open an issue or a pull request to add any information that might be missing.

--- a/src/Microsoft.Graph/Generated/requests/GraphServiceClient.cs
+++ b/src/Microsoft.Graph/Generated/requests/GraphServiceClient.cs
@@ -75,7 +75,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceInvitations request builder.
         /// </summary>
-        public IGraphServiceInvitationsCollectionRequestBuilder Invitations
+        public virtual IGraphServiceInvitationsCollectionRequestBuilder Invitations
         {
             get
             {
@@ -86,7 +86,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceUsers request builder.
         /// </summary>
-        public IGraphServiceUsersCollectionRequestBuilder Users
+        public virtual IGraphServiceUsersCollectionRequestBuilder Users
         {
             get
             {
@@ -97,7 +97,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceApplicationTemplates request builder.
         /// </summary>
-        public IGraphServiceApplicationTemplatesCollectionRequestBuilder ApplicationTemplates
+        public virtual IGraphServiceApplicationTemplatesCollectionRequestBuilder ApplicationTemplates
         {
             get
             {
@@ -108,7 +108,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceAuthenticationMethodConfigurations request builder.
         /// </summary>
-        public IGraphServiceAuthenticationMethodConfigurationsCollectionRequestBuilder AuthenticationMethodConfigurations
+        public virtual IGraphServiceAuthenticationMethodConfigurationsCollectionRequestBuilder AuthenticationMethodConfigurations
         {
             get
             {
@@ -119,7 +119,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceIdentityProviders request builder.
         /// </summary>
-        public IGraphServiceIdentityProvidersCollectionRequestBuilder IdentityProviders
+        public virtual IGraphServiceIdentityProvidersCollectionRequestBuilder IdentityProviders
         {
             get
             {
@@ -130,7 +130,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceApplications request builder.
         /// </summary>
-        public IGraphServiceApplicationsCollectionRequestBuilder Applications
+        public virtual IGraphServiceApplicationsCollectionRequestBuilder Applications
         {
             get
             {
@@ -141,7 +141,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceCertificateBasedAuthConfiguration request builder.
         /// </summary>
-        public IGraphServiceCertificateBasedAuthConfigurationCollectionRequestBuilder CertificateBasedAuthConfiguration
+        public virtual IGraphServiceCertificateBasedAuthConfigurationCollectionRequestBuilder CertificateBasedAuthConfiguration
         {
             get
             {
@@ -152,7 +152,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceContacts request builder.
         /// </summary>
-        public IGraphServiceContactsCollectionRequestBuilder Contacts
+        public virtual IGraphServiceContactsCollectionRequestBuilder Contacts
         {
             get
             {
@@ -163,7 +163,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceContracts request builder.
         /// </summary>
-        public IGraphServiceContractsCollectionRequestBuilder Contracts
+        public virtual IGraphServiceContractsCollectionRequestBuilder Contracts
         {
             get
             {
@@ -174,7 +174,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDevices request builder.
         /// </summary>
-        public IGraphServiceDevicesCollectionRequestBuilder Devices
+        public virtual IGraphServiceDevicesCollectionRequestBuilder Devices
         {
             get
             {
@@ -185,7 +185,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDirectoryObjects request builder.
         /// </summary>
-        public IGraphServiceDirectoryObjectsCollectionRequestBuilder DirectoryObjects
+        public virtual IGraphServiceDirectoryObjectsCollectionRequestBuilder DirectoryObjects
         {
             get
             {
@@ -196,7 +196,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDirectoryRoles request builder.
         /// </summary>
-        public IGraphServiceDirectoryRolesCollectionRequestBuilder DirectoryRoles
+        public virtual IGraphServiceDirectoryRolesCollectionRequestBuilder DirectoryRoles
         {
             get
             {
@@ -207,7 +207,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDirectoryRoleTemplates request builder.
         /// </summary>
-        public IGraphServiceDirectoryRoleTemplatesCollectionRequestBuilder DirectoryRoleTemplates
+        public virtual IGraphServiceDirectoryRoleTemplatesCollectionRequestBuilder DirectoryRoleTemplates
         {
             get
             {
@@ -218,7 +218,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDomainDnsRecords request builder.
         /// </summary>
-        public IGraphServiceDomainDnsRecordsCollectionRequestBuilder DomainDnsRecords
+        public virtual IGraphServiceDomainDnsRecordsCollectionRequestBuilder DomainDnsRecords
         {
             get
             {
@@ -229,7 +229,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDomains request builder.
         /// </summary>
-        public IGraphServiceDomainsCollectionRequestBuilder Domains
+        public virtual IGraphServiceDomainsCollectionRequestBuilder Domains
         {
             get
             {
@@ -240,7 +240,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceGroups request builder.
         /// </summary>
-        public IGraphServiceGroupsCollectionRequestBuilder Groups
+        public virtual IGraphServiceGroupsCollectionRequestBuilder Groups
         {
             get
             {
@@ -251,7 +251,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceGroupSettings request builder.
         /// </summary>
-        public IGraphServiceGroupSettingsCollectionRequestBuilder GroupSettings
+        public virtual IGraphServiceGroupSettingsCollectionRequestBuilder GroupSettings
         {
             get
             {
@@ -262,7 +262,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceGroupSettingTemplates request builder.
         /// </summary>
-        public IGraphServiceGroupSettingTemplatesCollectionRequestBuilder GroupSettingTemplates
+        public virtual IGraphServiceGroupSettingTemplatesCollectionRequestBuilder GroupSettingTemplates
         {
             get
             {
@@ -273,7 +273,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceLocalizations request builder.
         /// </summary>
-        public IGraphServiceLocalizationsCollectionRequestBuilder Localizations
+        public virtual IGraphServiceLocalizationsCollectionRequestBuilder Localizations
         {
             get
             {
@@ -284,7 +284,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceOauth2PermissionGrants request builder.
         /// </summary>
-        public IGraphServiceOauth2PermissionGrantsCollectionRequestBuilder Oauth2PermissionGrants
+        public virtual IGraphServiceOauth2PermissionGrantsCollectionRequestBuilder Oauth2PermissionGrants
         {
             get
             {
@@ -295,7 +295,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceOrganization request builder.
         /// </summary>
-        public IGraphServiceOrganizationCollectionRequestBuilder Organization
+        public virtual IGraphServiceOrganizationCollectionRequestBuilder Organization
         {
             get
             {
@@ -306,7 +306,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServicePermissionGrants request builder.
         /// </summary>
-        public IGraphServicePermissionGrantsCollectionRequestBuilder PermissionGrants
+        public virtual IGraphServicePermissionGrantsCollectionRequestBuilder PermissionGrants
         {
             get
             {
@@ -317,7 +317,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceScopedRoleMemberships request builder.
         /// </summary>
-        public IGraphServiceScopedRoleMembershipsCollectionRequestBuilder ScopedRoleMemberships
+        public virtual IGraphServiceScopedRoleMembershipsCollectionRequestBuilder ScopedRoleMemberships
         {
             get
             {
@@ -328,7 +328,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceServicePrincipals request builder.
         /// </summary>
-        public IGraphServiceServicePrincipalsCollectionRequestBuilder ServicePrincipals
+        public virtual IGraphServiceServicePrincipalsCollectionRequestBuilder ServicePrincipals
         {
             get
             {
@@ -339,7 +339,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSubscribedSkus request builder.
         /// </summary>
-        public IGraphServiceSubscribedSkusCollectionRequestBuilder SubscribedSkus
+        public virtual IGraphServiceSubscribedSkusCollectionRequestBuilder SubscribedSkus
         {
             get
             {
@@ -350,7 +350,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceWorkbooks request builder.
         /// </summary>
-        public IGraphServiceWorkbooksCollectionRequestBuilder Workbooks
+        public virtual IGraphServiceWorkbooksCollectionRequestBuilder Workbooks
         {
             get
             {
@@ -361,7 +361,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServicePlaces request builder.
         /// </summary>
-        public IGraphServicePlacesCollectionRequestBuilder Places
+        public virtual IGraphServicePlacesCollectionRequestBuilder Places
         {
             get
             {
@@ -372,7 +372,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDrives request builder.
         /// </summary>
-        public IGraphServiceDrivesCollectionRequestBuilder Drives
+        public virtual IGraphServiceDrivesCollectionRequestBuilder Drives
         {
             get
             {
@@ -383,7 +383,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceShares request builder.
         /// </summary>
-        public IGraphServiceSharesCollectionRequestBuilder Shares
+        public virtual IGraphServiceSharesCollectionRequestBuilder Shares
         {
             get
             {
@@ -394,7 +394,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSites request builder.
         /// </summary>
-        public IGraphServiceSitesCollectionRequestBuilder Sites
+        public virtual IGraphServiceSitesCollectionRequestBuilder Sites
         {
             get
             {
@@ -405,7 +405,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSchemaExtensions request builder.
         /// </summary>
-        public IGraphServiceSchemaExtensionsCollectionRequestBuilder SchemaExtensions
+        public virtual IGraphServiceSchemaExtensionsCollectionRequestBuilder SchemaExtensions
         {
             get
             {
@@ -416,7 +416,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceGroupLifecyclePolicies request builder.
         /// </summary>
-        public IGraphServiceGroupLifecyclePoliciesCollectionRequestBuilder GroupLifecyclePolicies
+        public virtual IGraphServiceGroupLifecyclePoliciesCollectionRequestBuilder GroupLifecyclePolicies
         {
             get
             {
@@ -427,7 +427,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceAgreementAcceptances request builder.
         /// </summary>
-        public IGraphServiceAgreementAcceptancesCollectionRequestBuilder AgreementAcceptances
+        public virtual IGraphServiceAgreementAcceptancesCollectionRequestBuilder AgreementAcceptances
         {
             get
             {
@@ -438,7 +438,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceAgreements request builder.
         /// </summary>
-        public IGraphServiceAgreementsCollectionRequestBuilder Agreements
+        public virtual IGraphServiceAgreementsCollectionRequestBuilder Agreements
         {
             get
             {
@@ -449,7 +449,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDataPolicyOperations request builder.
         /// </summary>
-        public IGraphServiceDataPolicyOperationsCollectionRequestBuilder DataPolicyOperations
+        public virtual IGraphServiceDataPolicyOperationsCollectionRequestBuilder DataPolicyOperations
         {
             get
             {
@@ -460,7 +460,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSubscriptions request builder.
         /// </summary>
-        public IGraphServiceSubscriptionsCollectionRequestBuilder Subscriptions
+        public virtual IGraphServiceSubscriptionsCollectionRequestBuilder Subscriptions
         {
             get
             {
@@ -471,7 +471,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceChats request builder.
         /// </summary>
-        public IGraphServiceChatsCollectionRequestBuilder Chats
+        public virtual IGraphServiceChatsCollectionRequestBuilder Chats
         {
             get
             {
@@ -482,7 +482,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceTeams request builder.
         /// </summary>
-        public IGraphServiceTeamsCollectionRequestBuilder Teams
+        public virtual IGraphServiceTeamsCollectionRequestBuilder Teams
         {
             get
             {
@@ -493,7 +493,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceTeamsTemplates request builder.
         /// </summary>
-        public IGraphServiceTeamsTemplatesCollectionRequestBuilder TeamsTemplates
+        public virtual IGraphServiceTeamsTemplatesCollectionRequestBuilder TeamsTemplates
         {
             get
             {
@@ -504,7 +504,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceAuditLogs request builder.
         /// </summary>
-        public IAuditLogRootRequestBuilder AuditLogs
+        public virtual IAuditLogRootRequestBuilder AuditLogs
         {
             get
             {
@@ -515,7 +515,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceAuthenticationMethodsPolicy request builder.
         /// </summary>
-        public IAuthenticationMethodsPolicyRequestBuilder AuthenticationMethodsPolicy
+        public virtual IAuthenticationMethodsPolicyRequestBuilder AuthenticationMethodsPolicy
         {
             get
             {
@@ -526,7 +526,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceIdentity request builder.
         /// </summary>
-        public IIdentityContainerRequestBuilder Identity
+        public virtual IIdentityContainerRequestBuilder Identity
         {
             get
             {
@@ -537,7 +537,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceBranding request builder.
         /// </summary>
-        public IOrganizationalBrandingRequestBuilder Branding
+        public virtual IOrganizationalBrandingRequestBuilder Branding
         {
             get
             {
@@ -548,7 +548,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDirectory request builder.
         /// </summary>
-        public IDirectoryRequestBuilder Directory
+        public virtual IDirectoryRequestBuilder Directory
         {
             get
             {
@@ -559,7 +559,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceMe request builder.
         /// </summary>
-        public IUserRequestBuilder Me
+        public virtual IUserRequestBuilder Me
         {
             get
             {
@@ -570,7 +570,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServicePolicies request builder.
         /// </summary>
-        public IPolicyRootRequestBuilder Policies
+        public virtual IPolicyRootRequestBuilder Policies
         {
             get
             {
@@ -581,7 +581,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceEducation request builder.
         /// </summary>
-        public IEducationRootRequestBuilder Education
+        public virtual IEducationRootRequestBuilder Education
         {
             get
             {
@@ -592,7 +592,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceRoleManagement request builder.
         /// </summary>
-        public IRoleManagementRequestBuilder RoleManagement
+        public virtual IRoleManagementRequestBuilder RoleManagement
         {
             get
             {
@@ -603,7 +603,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDrive request builder.
         /// </summary>
-        public IDriveRequestBuilder Drive
+        public virtual IDriveRequestBuilder Drive
         {
             get
             {
@@ -614,7 +614,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceCommunications request builder.
         /// </summary>
-        public ICloudCommunicationsRequestBuilder Communications
+        public virtual ICloudCommunicationsRequestBuilder Communications
         {
             get
             {
@@ -625,7 +625,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceIdentityGovernance request builder.
         /// </summary>
-        public IIdentityGovernanceRequestBuilder IdentityGovernance
+        public virtual IIdentityGovernanceRequestBuilder IdentityGovernance
         {
             get
             {
@@ -636,7 +636,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDeviceAppManagement request builder.
         /// </summary>
-        public IDeviceAppManagementRequestBuilder DeviceAppManagement
+        public virtual IDeviceAppManagementRequestBuilder DeviceAppManagement
         {
             get
             {
@@ -647,7 +647,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceDeviceManagement request builder.
         /// </summary>
-        public IDeviceManagementRequestBuilder DeviceManagement
+        public virtual IDeviceManagementRequestBuilder DeviceManagement
         {
             get
             {
@@ -658,7 +658,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceReports request builder.
         /// </summary>
-        public IReportRootRequestBuilder Reports
+        public virtual IReportRootRequestBuilder Reports
         {
             get
             {
@@ -669,7 +669,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSearch request builder.
         /// </summary>
-        public ISearchEntityRequestBuilder Search
+        public virtual ISearchEntityRequestBuilder Search
         {
             get
             {
@@ -680,7 +680,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServicePlanner request builder.
         /// </summary>
-        public IPlannerRequestBuilder Planner
+        public virtual IPlannerRequestBuilder Planner
         {
             get
             {
@@ -691,7 +691,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServicePrint request builder.
         /// </summary>
-        public IPrintRequestBuilder Print
+        public virtual IPrintRequestBuilder Print
         {
             get
             {
@@ -702,7 +702,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceSecurity request builder.
         /// </summary>
-        public ISecurityRequestBuilder Security
+        public virtual ISecurityRequestBuilder Security
         {
             get
             {
@@ -713,7 +713,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceAppCatalogs request builder.
         /// </summary>
-        public IAppCatalogsRequestBuilder AppCatalogs
+        public virtual IAppCatalogsRequestBuilder AppCatalogs
         {
             get
             {
@@ -724,7 +724,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceTeamwork request builder.
         /// </summary>
-        public ITeamworkRequestBuilder Teamwork
+        public virtual ITeamworkRequestBuilder Teamwork
         {
             get
             {
@@ -735,7 +735,7 @@ namespace Microsoft.Graph
         /// <summary>
         /// Gets the GraphServiceInformationProtection request builder.
         /// </summary>
-        public IInformationProtectionRequestBuilder InformationProtection
+        public virtual IInformationProtectionRequestBuilder InformationProtection
         {
             get
             {


### PR DESCRIPTION
This PR makes the properties of GraphServiceClient virtual to enable the use of mocking frameworks such as Moq to be able to override the implementations provided in the class after the dropping of the IGraphServiceClient interface.

Sdk users should now be able to initialize an mock of the GraphServiceClient for testing by doing something similar to the code below.

**Example**
```cs
// create mocks
var mockAuthProvider = new Mock<IAuthenticationProvider>();
var mockHttpProvider = new Mock<IHttpProvider>();
var mockGraphClient = new Mock<GraphServiceClient>(mockAuthProvider.Object, mockHttpProvider.Object);

ManagedDevice md = new ManagedDevice
{
    Id = "1",
    DeviceCategory = new DeviceCategory()
    {
        Description = "Sample Description"
    }
};

// setup the calls
mockGraphClient.Setup(g => g.DeviceManagement.ManagedDevices["1"].Request().GetAsync(CancellationToken.None)).Returns(Task.Run(() => md)).Verifiable();
var graphClient = mockGraphClient.Object;

// Act
var device = await graphClient.DeviceManagement.ManagedDevices["1"].Request().GetAsync(CancellationToken.None);

// Assert
Assert.Equal("1",device.Id);
```

This PR also updates TokenCredential code samples involving app only flows to be less misleading as scopes are not configured on the client side for ClientSecretCredential and ClientCertificateCredential.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1040)