### PR TITLE
Disambiguate Task

### DIFF
--- a/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
+++ b/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Graph
     using System.Collections.Generic;
     using System.IO;
     using System.Threading.Tasks;
+    using Task = System.Threading.Tasks.Task;
 
     /// <summary>
     /// Use this class to make resumable uploads or to upload large files. This
@@ -147,7 +148,7 @@ namespace Microsoft.Graph
                 if (uploadTries < maxTries)
                 {
                     // Exponential backoff in case of failures.
-                    await System.Threading.Tasks.Task.Delay(2000 * uploadTries * uploadTries).ConfigureAwait(false);
+                    await Task.Delay(2000 * uploadTries * uploadTries).ConfigureAwait(false);
                 }
             }
 

--- a/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
+++ b/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Graph
     using System.Collections.Generic;
     using System.IO;
     using System.Threading.Tasks;
-    using Task = System.Threading.Tasks.Task;
 
     /// <summary>
     /// Use this class to make resumable uploads or to upload large files. This
@@ -148,7 +147,7 @@ namespace Microsoft.Graph
                 if (uploadTries < maxTries)
                 {
                     // Exponential backoff in case of failures.
-                    await Task.Delay(2000 * uploadTries * uploadTries).ConfigureAwait(false);
+                    await System.Threading.Tasks.Task.Delay(2000 * uploadTries * uploadTries).ConfigureAwait(false);
                 }
             }
 

--- a/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
+++ b/src/Microsoft.Graph/Requests/Helpers/ChunkedUploadProvider.cs
@@ -147,7 +147,7 @@ namespace Microsoft.Graph
                 if (uploadTries < maxTries)
                 {
                     // Exponential backoff in case of failures.
-                    await Task.Delay(2000 * uploadTries * uploadTries).ConfigureAwait(false);
+                    await System.Threading.Tasks.Task.Delay(2000 * uploadTries * uploadTries).ConfigureAwait(false);
                 }
             }
 

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/MailTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/MailTests.cs
@@ -11,11 +11,10 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
     using System.IO;
     using System.Threading.Tasks;
     using Xunit;
-    using Task = System.Threading.Tasks.Task;
 
     public class MailTests : GraphTestBase
     {
-        public async Task<Message> createEmail(string emailBody)
+        public async System.Threading.Tasks.Task<Message> createEmail(string emailBody)
         {
             // Get the test user.
             var me = await graphClient.Me.Request().GetAsync();
@@ -43,7 +42,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
 
         // Tests the SendMail action.
         [Fact(Skip = "No CI set up for functional tests")]
-        public async Task MailSendMail()
+        public async System.Threading.Tasks.Task MailSendMail()
         {
             try
             {
@@ -70,7 +69,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
 
         //// Test that we can set an attachment on a mail, send it, and then retrieve it.
         [Fact(Skip = "No CI set up for functional tests")]
-        public async Task MailSendMailWithFileAttachment()
+        public async System.Threading.Tasks.Task MailSendMailWithFileAttachment()
         {
             try
             {
@@ -97,7 +96,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
         }
 
         [Fact(Skip = "No CI set up for functional tests")]
-        public async Task MailGetMailWithFileAttachment()
+        public async System.Threading.Tasks.Task MailGetMailWithFileAttachment()
         {
             try
             {
@@ -131,7 +130,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
         }
 
         [Fact(Skip = "No CI set up for functional tests")]
-        public async Task MailNextPageRequest()
+        public async System.Threading.Tasks.Task MailNextPageRequest()
         {
             try
             {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/MailTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Functional/MailTests.cs
@@ -11,6 +11,8 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Functional
     using System.IO;
     using System.Threading.Tasks;
     using Xunit;
+    using Task = System.Threading.Tasks.Task;
+
     public class MailTests : GraphTestBase
     {
         public async Task<Message> createEmail(string emailBody)

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ActionRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ActionRequestTests.cs
@@ -13,6 +13,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ActionRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ActionRequestTests.cs
@@ -13,7 +13,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -151,7 +150,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// The action is also inherited from the base class.
         /// </summary>
         [Fact]
-        public async Task PostAsync_CollectionOfPrimitivesReturnType()
+        public async System.Threading.Tasks.Task PostAsync_CollectionOfPrimitivesReturnType()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -212,7 +211,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the PostAsync() method for an action that returns a single entity (createLink).
         /// </summary>
         [Fact]
-        public async Task PostAsync_NonCollectionReturnType()
+        public async System.Threading.Tasks.Task PostAsync_NonCollectionReturnType()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -247,7 +246,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the PostAsync() method for an action that returns nothing (send).
         /// </summary>
         [Fact]
-        public async Task PostAsync_NoReturnValue()
+        public async System.Threading.Tasks.Task PostAsync_NoReturnValue()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/CollectionReferencesRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/CollectionReferencesRequestTests.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/CollectionReferencesRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/CollectionReferencesRequestTests.cs
@@ -12,7 +12,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -39,7 +38,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the AddAsync() method on the $ref navigation of an entity collection.
         /// </summary>
         [Fact]
-        public async Task AddAsync()
+        public async System.Threading.Tasks.Task AddAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -76,7 +75,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the AddAsync() method on the $ref navigation of an entity collection errors if ID isn't set on the supplied directoryObject.
         /// </summary>
         [Fact]
-        public async Task AddAsync_IdRequired()
+        public async System.Threading.Tasks.Task AddAsync_IdRequired()
         {
             var userToCreate = new User();
 

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/CollectionWithReferencesRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/CollectionWithReferencesRequestTests.cs
@@ -13,6 +13,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/CollectionWithReferencesRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/CollectionWithReferencesRequestTests.cs
@@ -13,7 +13,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -40,7 +39,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the GetAsync() method on the request for an entity collection that has a $ref navigation.
         /// </summary>
         [Fact]
-        public async Task GetAsync()
+        public async System.Threading.Tasks.Task GetAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityCollectionRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityCollectionRequestTests.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests that the AddAsync() method on an abstract entity collection request includes @odata.type.
         /// </summary>
         [Fact]
-        public async Task AddAsync_AbstractEntityContainsODataType()
+        public async System.Threading.Tasks.Task AddAsync_AbstractEntityContainsODataType()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityCollectionRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityCollectionRequestTests.cs
@@ -13,6 +13,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityCollectionRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityCollectionRequestTests.cs
@@ -13,7 +13,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -40,7 +39,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the GetAsync() method on an entity collection request.
         /// </summary>
         [Fact]
-        public async Task GetAsync()
+        public async System.Threading.Tasks.Task GetAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -101,7 +100,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the AddAsync() method on an entity collection request.
         /// </summary>
         [Fact]
-        public async Task AddAsync()
+        public async System.Threading.Tasks.Task AddAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityReferenceRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityReferenceRequestTests.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityReferenceRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityReferenceRequestTests.cs
@@ -12,7 +12,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -39,7 +38,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the DeleteAsync() method on an entity's $ref navigation.
         /// </summary>
         [Fact]
-        public async Task DeleteAsync()
+        public async System.Threading.Tasks.Task DeleteAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityRequestTests.cs
@@ -14,6 +14,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityRequestTests.cs
@@ -14,14 +14,13 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
     public class EntityRequestTests : RequestTestBase
     {
         [Fact]
-        public async Task GetAsync_InitializeCollectionProperties()
+        public async System.Threading.Tasks.Task GetAsync_InitializeCollectionProperties()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -67,7 +66,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         }
 
         [Fact]
-        public async Task DeleteAsync()
+        public async System.Threading.Tasks.Task DeleteAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage(HttpStatusCode.NoContent))
             {
@@ -113,7 +112,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         }
 
         [Fact]
-        public async Task UpdateAsync_EntityWithNoCollecitonProperties()
+        public async System.Threading.Tasks.Task UpdateAsync_EntityWithNoCollecitonProperties()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -144,12 +143,12 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         }
                 
         [Fact]
-        public async Task UpdateAsync()
+        public async System.Threading.Tasks.Task UpdateAsync()
         {
             await this.RequestWithItemInBody(true);
         }
 
-        private async Task RequestWithItemInBody(bool isUpdate)
+        private async System.Threading.Tasks.Task RequestWithItemInBody(bool isUpdate)
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityWithReferenceRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityWithReferenceRequestTests.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityWithReferenceRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/EntityWithReferenceRequestTests.cs
@@ -12,7 +12,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -39,7 +38,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the GetAsync() method on an entity that has a $ref navigation.
         /// </summary>
         [Fact]
-        public async Task GetAsync()
+        public async System.Threading.Tasks.Task GetAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/FunctionRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/FunctionRequestTests.cs
@@ -13,7 +13,6 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -129,7 +128,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         /// Tests the GetAsync() method for a function that returns a collection (reminderView).
         /// </summary>
         [Fact]
-        public async Task CollectionReturnType_GetAsync()
+        public async System.Threading.Tasks.Task CollectionReturnType_GetAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/FunctionRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/FunctionRequestTests.cs
@@ -13,6 +13,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/MediaEntityStreamRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/MediaEntityStreamRequestTests.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/MediaEntityStreamRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/MediaEntityStreamRequestTests.cs
@@ -12,7 +12,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -29,7 +28,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         }
 
         [Fact]
-        public async Task GetAsync()
+        public async System.Threading.Tasks.Task GetAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var responseStream = new MemoryStream())
@@ -55,7 +54,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         }
 
         [Fact]
-        public async Task PutAsync()
+        public async System.Threading.Tasks.Task PutAsync()
         {
             using (var requestStream = new MemoryStream())
             using (var httpResponseMessage = new HttpResponseMessage())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ThumbnailRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ThumbnailRequestTests.cs
@@ -12,7 +12,6 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
-using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {
@@ -29,7 +28,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         }
 
         [Fact]
-        public async Task ThumbnailContentStreamRequest_GetAsync()
+        public async System.Threading.Tasks.Task ThumbnailContentStreamRequest_GetAsync()
         {
             using (var httpResponseMessage = new HttpResponseMessage())
             using (var stringContent = new StringContent("body"))
@@ -60,7 +59,7 @@ namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
         }
 
         [Fact]
-        public async Task ThumbnailContentStreamRequest_PutAsync()
+        public async System.Threading.Tasks.Task ThumbnailContentStreamRequest_PutAsync()
         {
             using (var requestStream = new MemoryStream())
             using (var httpResponseMessage = new HttpResponseMessage())

--- a/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ThumbnailRequestTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Requests/Generated/ThumbnailRequestTests.cs
@@ -12,6 +12,7 @@ using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Task = System.Threading.Tasks.Task;
 
 namespace Microsoft.Graph.DotnetCore.Test.Requests.Generated
 {


### PR DESCRIPTION
Fixes https://github.com/microsoftgraph/msgraph-sdk-raptor/issues/704

The root cause is that there is an upcoming type in beta metadata that collides with System.Threading.Tasks.Task. Disambiguated those names in this PR.

The upcoming type:
```xml
<EntityType Name="task" BaseType="graph.baseTask"/>
```

Staging pipeline for beta is also using this repo, so fix initially goes in here. But I will apply the same fix in msgraph-beta-sdk-dotnet repo as well:
- [ ] Apply the same fix in beta service library repo.

----

### Pipeline run before the change:
#### Failing main project build:
https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=61504&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=006e6f7c-8314-5e02-a3df-483f3a1f4cfa&l=5859

#### Failing test project build:
https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=61583&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=006e6f7c-8314-5e02-a3df-483f3a1f4cfa&l=3983

----

### Pipeline run after the change:
https://microsoftgraph.visualstudio.com/Graph%20Developer%20Experiences/_build/results?buildId=61587&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=006e6f7c-8314-5e02-a3df-483f3a1f4cfa



###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1194)