### PR TITLE
Update README.md to reflect correct .NET framework version

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Integrate the [Microsoft Graph API](https://graph.microsoft.io) into your .NET
 project!
 
-The Microsoft Graph .NET Client Library targets .NetStandard 2.0 and .Net Framework 4.6.1.
+The Microsoft Graph .NET Client Library targets .NetStandard 2.0 and .Net Framework 4.6.2.
 
 ## Installation via NuGet
 


### PR DESCRIPTION
This PR fixes the incorrect minimum version for the v4 SDK in the readme in .Net Framework from 4.6.1 to 4.6.2 as outlined in the upgrade guide

Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1275