### PR TITLE
Fix broken links in TokenCredentials.md

### DIFF
--- a/docs/tokencredentials.md
+++ b/docs/tokencredentials.md
@@ -1,10 +1,10 @@
 # TokenCredentials Examples
 
-This document is aimed at helping users of the Microsoft Graph .NET SDK to quickly be able to move their code from AuthProviders providers present in the [Microsoft.Graph.Auth](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth) package to using TokenCredential instances provided from Azure.Identity package.
+This document is aimed at helping users of the Microsoft Graph .NET SDK to quickly be able to move their code from AuthProviders providers present in the deprecated [Microsoft.Graph.Auth](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth) package to using TokenCredential instances provided from Azure.Identity package.
 
 ## 1. InteractiveBrowserCredential
 
-This credential class provides a similar use to the [Interactive provider](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth#c-interactive-authentication-provider) and can be used as follows.
+This credential class provides authentication through an interactive browser prompt and similar functionality to the **deprecated Interactive AuthProvider** and can be used as follows.
 
 ```cs
 string[] scopes = {"User.Read"};
@@ -22,7 +22,7 @@ User me = await graphClient.Me.Request()
 
 ## 2. UsernamePasswordCredential
 
-This credential class provides a similar use to the [Username/password provider](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth#d-username-password-provider) and can be used as follows.
+This credential class provides the [username/password authentication flow](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#usernamepassword-ropc) and similar functionality to the **deprecated Username/password AuthProvider** and can be used as follows. 
 Use this flow only when you cannot use any of the other OAuth flows.
 
 ```cs
@@ -39,7 +39,7 @@ User me = await graphClient.Me.Request()
 
 ## 3. DeviceCodeCredential
 
-This credential class provides a similar use to the [Device code provider](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth#a-device-code-provider) and can be used as follows.
+This credential class provides the [device code authentication flow](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#device-code) flow and similar use to the **deprecated Device code AuthProvider** and can be used as follows.
 The device code flow enables sign in to devices by way of another device.
 
 ```cs
@@ -55,7 +55,7 @@ DeviceCodeCredentialOptions deviceCodeCredentialOptions = new DeviceCodeCredenti
 };
 DeviceCodeCredential deviceCodeCredential = new DeviceCodeCredential(deviceCodeCredentialOptions);
 
-GraphServiceClient graphServiceClient = new GraphServiceClient(deviceCodeCredential, scopes);
+GraphServiceClient graphClient = new GraphServiceClient(deviceCodeCredential, scopes);
 
 User me = await graphClient.Me.Request()
                 .GetAsync();
@@ -63,7 +63,7 @@ User me = await graphClient.Me.Request()
 
 ## 4. ClientSecretCredential
 
-This credential class provides a similar use to the [Client Credential Provider](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth#b-client-credential-provider) with the use of a client secret and can be used as follows.
+This credential class provides the [Client credentials authentication flow using an app secret](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#client-credentials) a similar use to the **deprecated Client Credential AuthProvider** with the use of a client secret and can be used as follows.
 The device code flow enables sign in to devices by way of another device.
 
 ```cs
@@ -71,7 +71,7 @@ string[] scopes = {"https://graph.microsoft.com/.default"};
 
 ClientSecretCredential clientSecretCredential = new ClientSecretCredential(tenantId, clientId, clientSecret); 
 
-GraphServiceClient graphServiceClient = new GraphServiceClient(clientSecretCredential, scopes);
+GraphServiceClient graphClient = new GraphServiceClient(clientSecretCredential, scopes);
 
 User me = await graphClient.Users["user-id"].Request()
                 .GetAsync();
@@ -79,7 +79,7 @@ User me = await graphClient.Users["user-id"].Request()
 
 ## 5. ClientCertificateCredential
 
-This credential class provides a similar use to the [Client Credential Provider](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth#b-client-credential-provider) with the use of a client certificate and can be used as follows.
+This credential class provides the [Client credentials authentication flow using an certificate](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#client-credentials) a similar use to the **deprecated Client Credential AuthProvider** with the use of a client certificate and can be used as follows.
 
 ```cs
 string[] scopes = {"https://graph.microsoft.com/.default"};
@@ -89,7 +89,7 @@ ClientCertificateCredential clientCertificateCredential = new ClientCertificateC
 // or pass instance of X509Certificate2
 // ClientCertificateCredential clientCertificateCredential = new ClientCertificateCredential(tenantId, clientId, certificatePath);
 
-GraphServiceClient graphServiceClient = new GraphServiceClient(clientCertificateCredential, scopes);
+GraphServiceClient graphClient = new GraphServiceClient(clientCertificateCredential, scopes);
 
 User me = await graphClient.Users["user-id"].Request()
                 .GetAsync();
@@ -97,14 +97,14 @@ User me = await graphClient.Users["user-id"].Request()
 
 ## 6. AuthorizationCodeCredential
 
-This credential class provides a similar use to the [Authorization code provider](https://github.com/microsoftgraph/msgraph-sdk-dotnet-auth#a-authorization-code-provider) with the use of a client secret and can be used as follows. The authorization code flow enables native and web apps to securely obtain tokens in the name of the user. 
+This credential class provides the [Authorization code authentication flow](https://docs.microsoft.com/en-us/azure/active-directory/develop/msal-authentication-flows#authorization-code) a similar use to the **Authorization code AuthProvider** with the use of a client secret and can be used as follows. The authorization code flow enables native and web apps to securely obtain tokens in the name of the user. 
 
 ```cs
 string[] scopes = {"User.Read"};
 
 AuthorizationCodeCredential authorizationCodeCredential = new AuthorizationCodeCredential(tenantId, clientId,  clientSecret, authCode);
 
-GraphServiceClient graphServiceClient = new GraphServiceClient(authorizationCodeCredential, scopes);
+GraphServiceClient graphClient = new GraphServiceClient(authorizationCodeCredential, scopes);
 
 User me = await graphClient.Me.Request()
                 .GetAsync();
@@ -116,7 +116,7 @@ It is also useful to know that Azure.Identity provides other TokenCredentials th
 
 ## 1. EnvironmentCredential
 
-This credential enables the used of defined environment variables to configure authentication. The environment varables used are as follows.
+This credential enables the used of defined environment variables to configure authentication. The environment variables used are as follows.
 
 - AZURE_TENANT_ID -   The Azure Active Directory tenant(directory) ID.
 - AZURE_CLIENT_ID -   The client(application) ID of an App Registration in the tenant.
@@ -125,13 +125,13 @@ This credential enables the used of defined environment variables to configure a
 - AZURE_USERNAME -    The username, also known as upn, of an Azure Active Directory user account.
 - AZURE_PASSWORD -    The password of the Azure Active Directory user account. Note this does not support accounts with MFA enabled.
 
-Based on the environment varialbe defined, this credential ultimately uses a `ClientSecretCredential` or `UsernamePasswordCredential` to perform the authentication using these details.
+Based on the environment variable defined, this credential ultimately uses a `ClientSecretCredential` or `UsernamePasswordCredential` to perform the authentication using these details.
 ```cs
 string[] scopes = {"User.Read"};
 
 EnvironmentCredential environmentCredential = new EnvironmentCredential();
 
-GraphServiceClient graphServiceClient = new GraphServiceClient(environmentCredential, scopes);
+GraphServiceClient graphClient = new GraphServiceClient(environmentCredential, scopes);
 
 User me = await graphClient.Me.Request()
                 .GetAsync();
@@ -155,8 +155,14 @@ InteractiveBrowserCredential myBrowserCredential = new InteractiveBrowserCredent
 TokenCredential [] tokenCredentials = new TokenCredential[]{ environmentCredential , myBrowserCredential };
 ChainedTokenCredential chainedTokenCredential = new ChainedTokenCredential(tokenCredentials);
 
-GraphServiceClient graphServiceClient = new GraphServiceClient(chainedTokenCredential, scopes);
+GraphServiceClient graphClient = new GraphServiceClient(chainedTokenCredential, scopes);
 
 User me = await graphClient.Me.Request()
                 .GetAsync();
 ```
+
+
+## Useful References
+
+- [Graph API Permissions/Scopes](https://docs.microsoft.com/en-us/graph/permissions-reference)
+- [Azure.Identity Library Reference Docs](https://docs.microsoft.com/en-us/dotnet/api/azure.identity?view=azure-dotnet)


### PR DESCRIPTION
This PR closes #1295 

Changes include: - 
- With the deprecation of the Auth lib, we seem to have broken some links in the ReadMe from the repo. This PR fixes that. 
- Fixes some spelling errors
- Adds links to Graph Permissions reference and Azure.Identity docs.

