### PR TITLE
Refactor code samples after request configuration revamp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,12 +16,12 @@ When a new package is about to be released, changes in dev will be merged into m
 Some things to note about this project:
 
 ### How the library is built
-The .Net client library has a handwritten set of core files and two folders of generated models and request builders. These models and request builders are generated using the [MSGraph SDK Code Generator](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator). **Changes made to the ```Models``` and ```Requests``` folders will be overwritten** the next time the generator is run. 
+The .Net client library has a handwritten set of core files and folders for generated models and request builders. These models and request builders are generated using [Kiota](https://github.com/microsoft/kiota). **Changes made to the ```Generated``` folder will be overwritten** the next time the generator is run. 
 
 ### How the generator works
-You can view the [README](https://github.com/microsoftgraph/MSGraph-SDK-Code-Generator/blob/master/README.md) for a full run-through of its capabilities.
+You can view the [README](https://github.com/microsoft/kiota/blob/main/README.md) for a full run-through of its capabilities.
 
-For the purposes of the .Net client library, the generator runs through an OData-compliant metadata file published by Microsoft Graph (https://graph.microsoft.com/v1.0/$metadata) and builds up an in-memory list of models. These models are converted into C# code files using T4 templates.
+For the purposes of the .Net client library, the generator runs through an openApi file generated from the CSDL document file published by Microsoft Graph (https://graph.microsoft.com/v1.0/$metadata) and builds up an in-memory list of models.
 
 ### When new features are added to the library
 Generation happens as part of a manual process that occurs once a significant change or set of changes has been added to the Graph. This may include:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Microsoft Graph .NET Client Library
 
-[![Build status](https://ci.appveyor.com/api/projects/status/m8qncaosr2ry4ks6/branch/master?svg=true)](https://ci.appveyor.com/project/MIchaelMainer/msgraph-sdk-dotnet/branch/master)
+[![Validate Pull Request](https://github.com/microsoftgraph/msgraph-sdk-dotnet/actions/workflows/validatePullRequest.yml/badge.svg)](https://github.com/microsoftgraph/msgraph-sdk-dotnet/actions/workflows/validatePullRequest.yml)
 [![NuGet Version](https://buildstats.info/nuget/Microsoft.Graph)](https://www.nuget.org/packages/Microsoft.Graph/)
 
 Integrate the [Microsoft Graph API](https://graph.microsoft.io) into your .NET

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -29,12 +29,11 @@ Some collections, like the groups collection, can be changed. To create a group 
 
 ```csharp
 var groupToCreate = new Group
-    {
-		GroupTypes = new List<string> { "Unified" },
-		DisplayName = "Unified group",
-		Description = "Best group ever",
-		...
-	};
+{
+    GroupTypes = new List<string> { "Unified" },
+    DisplayName = "Unified group",
+    Description = "Best group ever"
+};
 	
 var newGroup = await graphServiceClient
 							.Groups
@@ -49,9 +48,8 @@ To expand a collection, you call `Expand` on the collection request object with 
 
 ```csharp
 var children = await graphServiceClient
-                         .Me
-                         .Drive
-						 .Items[itemId]
-						 .Children
-						 .GetAsync((q) => q.Expand = new string[] { "thumbnails" });
+    .Drive
+    .Items["itemId"]
+    .Children
+    .GetAsync((requestConfiguration) => requestConfiguration.QueryParameters.Expand = new[] { "thumbnails" });
 ```

--- a/docs/headers.md
+++ b/docs/headers.md
@@ -4,13 +4,16 @@ The .NET Client Library allows you to add your own custom request headers and in
 
 ## Adding request headers
 
-Custom headers can be added by creating a new option collection and adding it to the request object:
+Custom headers can be added by using the requestConfiguration object and adding it to the headers collection:
 
 ```csharp
-
-var newObject = graphServiceClient
-	.Object
-	.Request(options)
-	.PatchAsync(h: h => { h.Add("Etag", "etag"); h.Add("If-Match", "ifmatch"); );
+var message = await graphServiceClient
+    .Me
+    .Messages["message-id"]
+    .GetAsync((requestConfiguration) =>
+    {
+        requestConfiguration.Headers.Add("Etag", "etag");
+        requestConfiguration.Headers.Add("If-Match", "ifmatch");
+    });
 ```
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -38,9 +38,7 @@ The resource model classes are generated based on the $metadata description of t
 
 ## Requests
 
-To make requests against the service, you'll need to build a request using the request builders of the client. The request builders are responsible for building the request URL while the `Request()` method of a request builder will build the request object. The request builder patterns are intended to mirror the REST API pattern.
-
-**Note:** Request and request builder classes are generated based on the $metadata description of the service. Interfaces are provided for each of these classes to enable easy unit testing around the logic contained in the classes. Since these interfaces are also generated, their signatures are subject to change without being considered a breaking change in the library. Anybody consuming these interfaces should be prepared for the class names or interface definitions to change between library versions.
+To make requests against the service, you'll need to build a request using the request builders of the client. The request builder patterns are intended to mirror the REST API pattern.
 
 ### 1. Request builders
 
@@ -50,7 +48,7 @@ You get the first request builder from the `GraphServiceClient` object. For exam
 |:----------|:----------------------:|:-------------------------------|
 |Get me     | graphServiceClient.Me  | GET graph.microsoft.com/v1.0/me|
  
-The call will return an `IUserRequestBuilder` object. From Me you can continue to chain the request builders.
+The call will return a `UserRequestBuilder` object. From Me you can continue to chain the request builders.
 
 The [Microsoft Graph service documentation](https://graph.microsoft.io/en-us/docs) has more details about the full functionality of the API.
 
@@ -75,8 +73,7 @@ If you only want to retrieve certain properties of a resource you can select the
 ``` csharp
 var user = await graphServiceClient
     .Me
-    .Request()
-    .GetAsync(q: q => q.Select = new string[] { "id"});
+    .GetAsync( requestConfiguration => requestConfiguration.QueryParameters.Select = new string[] { "id"});
 ```
 
 All properties other than `Id` will be null on the returned user object.

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -31,16 +31,16 @@ long offset = 0;         // cursor location for updating the Range header.
 byte[] bytesInStream;                    // bytes in range returned by chunk download.
 
 // Get the collection of drive items. We'll only use one.
-IDriveItemChildrenCollectionPage driveItems = await graphClient.Me.Drive.Root.Children.Request().GetAsync();
+var driveItems = await graphClient.Drive.Root.Children.GetAsync();
 
-foreach (var item in driveItems)
+foreach (var item in driveItems.Value)
 {
     // Let's download the first file we get in the response.
     if (item.File != null)
     {
         // We'll use the file metadata to determine size and the name of the downloaded file
         // and to get the download URL.
-        var driveItemInfo = await graphClient.Me.Drive.Items[item.Id].Request().GetAsync();
+        var driveItemInfo = await graphClient.Drive.Items[item.Id].GetAsync();
 
         // Get the download URL. This URL is preauthenticated and has a short TTL.
         object downloadUrl;


### PR DESCRIPTION
This PR closes #1335 

It updates the samples in the upgrade guide to reflect changes to the request configuration after changes made in https://github.com/microsoft/kiota/pull/1520

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1337)