### PR TITLE
Update MessageSingleValueExtendedPropertiesCollectionRequest.cs

### DIFF
--- a/src/Microsoft.Graph/Generated/requests/MessageSingleValueExtendedPropertiesCollectionRequest.cs
+++ b/src/Microsoft.Graph/Generated/requests/MessageSingleValueExtendedPropertiesCollectionRequest.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Graph
         public System.Threading.Tasks.Task<SingleValueLegacyExtendedProperty> AddAsync(SingleValueLegacyExtendedProperty singleValueLegacyExtendedProperty, CancellationToken cancellationToken = default)
         {
             this.ContentType = CoreConstants.MimeTypeNames.Application.Json;
-            this.Method = HttpMethods.POST;
+            this.Method = HttpMethods.PATCH;
             return this.SendAsync<SingleValueLegacyExtendedProperty>(singleValueLegacyExtendedProperty, cancellationToken);
         }
 
@@ -55,7 +55,7 @@ namespace Microsoft.Graph
         public System.Threading.Tasks.Task<GraphResponse<SingleValueLegacyExtendedProperty>> AddResponseAsync(SingleValueLegacyExtendedProperty singleValueLegacyExtendedProperty, CancellationToken cancellationToken = default)
         {
             this.ContentType = CoreConstants.MimeTypeNames.Application.Json;
-            this.Method = HttpMethods.POST;
+            this.Method = HttpMethods.PATCH;
             return this.SendAsyncWithGraphResponse<SingleValueLegacyExtendedProperty>(singleValueLegacyExtendedProperty, cancellationToken);
         }
 


### PR DESCRIPTION
Request to add a single-value extended property to a specific message should use PATCH instead of POST as stated in [documentation](https://learn.microsoft.com/en-us/graph/api/singlevaluelegacyextendedproperty-post-singlevalueextendedproperties?view=graph-rest-1.0).


###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1497)