### PR TITLE
Upgade guide update and release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project does adheres to [Semantic Versioning](https://semver.org/spec/v
 
 ## [Unreleased]
 
-- [Breaking] Renames `CreateXXXRequestInformation` methods to `ToXXXRequestInformation`
+- [Breaking] Renames `CreateXXXRequestInformation` methods to `ToXXXRequestInformation
+- Adds `IAuthenticationProvider` parameter to GraphServiceClient constructor taking a httpClient instance.
 - Latest metadata updates from 12th January 2023 snapshot
 
 ## [5.0.0-rc.1] - 2022-12-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project does adheres to [Semantic Versioning](https://semver.org/spec/v
 
 ## [Unreleased]
 
+## [5.0.0-rc.2] - 2023-01-11
+
+### Changed
+
 - [Breaking] Renames `CreateXXXRequestInformation` methods to `ToXXXRequestInformation
 - Adds `IAuthenticationProvider` parameter to GraphServiceClient constructor taking a httpClient instance.
 - Latest metadata updates from 12th January 2023 snapshot

--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -59,12 +59,12 @@ The `RequestInformation` class is now used to represent requests in the SDK and 
 // Get the requestInfomation to make a GET request
 var requestInformation = graphServiceClient
                          .DirectoryObjects
-                         .CreateGetRequestInformation();
+                         .ToGetRequestInformation();
 
 // Get the requestInfomation to make a POST request
 var requestInformation = graphServiceClient
                          .DirectoryObjects
-                         .CreatePostRequestInformation();
+                         .ToPostRequestInformation();
 ```
 
 ### Removal of `Request()` from the fluent API
@@ -262,12 +262,12 @@ Apart from passing instances of `HttpRequestMessage`, batch requests support the
 ```cs
 var requestInformation = graphServiceClient
                          .Users
-                         .CreateGetRequestInformation();
+                         .ToGetRequestInformation();
 
 // create the content
 var batchRequestContent = new BatchRequestContent(graphServiceClient);
 // add steps
-var requestStepId = batchRequestContent.AddBatchRequestStep(requestInformation);
+var requestStepId = await batchRequestContent.AddBatchRequestStepAsync(requestInformation);
 
 // send and get back response
 var batchResponseContent = await graphServiceClient.Batch.PostAsync(batchRequestContent);

--- a/src/Microsoft.Graph/GraphServiceClient.cs
+++ b/src/Microsoft.Graph/GraphServiceClient.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Graph
         private static readonly GraphClientOptions graphClientOptions = new GraphClientOptions
         {
             GraphServiceLibraryClientVersion = $"{assemblyVersion.Major}.{assemblyVersion.Minor}.{assemblyVersion.Build}",
-            GraphServiceTargetVersion = "v1.0",
+            GraphServiceTargetVersion = string.Empty,
         };
 
         /// <summary>
@@ -70,10 +70,13 @@ namespace Microsoft.Graph
         /// Constructs a new <see cref="GraphServiceClient"/>.
         /// </summary>
         /// <param name="httpClient">The customized <see cref="HttpClient"/> to be used for making requests</param>
+        /// <param name="authenticationProvider">The <see cref="IAuthenticationProvider"/> for authenticating request messages.
+        /// Defaults to <see cref="AnonymousAuthenticationProvider"/> so that authentication is handled by custom middleware in the httpClient</param>
         /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0"</param>
         public GraphServiceClient(
             HttpClient httpClient,
-            string baseUrl = null):this(new BaseGraphRequestAdapter(new AnonymousAuthenticationProvider(), graphClientOptions, httpClient: httpClient),baseUrl)
+            IAuthenticationProvider authenticationProvider = null,
+            string baseUrl = null):this(new BaseGraphRequestAdapter(authenticationProvider ?? new AnonymousAuthenticationProvider(), graphClientOptions, httpClient: httpClient),baseUrl)
         {
         }
 

--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -25,12 +25,12 @@
     <!-- VersionPrefix minor version should not be set when the change comes from the generator. It will be updated automatically. -->
     <!-- VersionPrefix minor version must be manually set when making manual changes to code. -->
     <!-- VersionPrefix major and patch versions must be manually set. -->
-    <VersionSuffix>rc.1</VersionSuffix>
+    <VersionSuffix>rc.2</VersionSuffix>
     <PackageReleaseNotes>
-- Release candidate 1
-- Adds support for multi-value headers
-- Fixes Guid types represented as strings
-- Latest metadata updates from 14th December 2022 snapshot
+- Release candidate 2
+- [Breaking] Renames `CreateXXXRequestInformation` methods to `ToXXXRequestInformation
+- Adds `IAuthenticationProvider` parameter to GraphServiceClient constructor taking a httpClient instance.
+- Latest metadata updates from 12th January 2023 snapshot
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>


### PR DESCRIPTION
This PR
- Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1609 to omit v1 in the telemetry header
- Closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1601 to create easier passing of `IAuthenticationProvider` when using the httpClient
- Updates the updated guide to capture renaming `CreateXXXRequestInformation` methods to `ToXXXRequestInformation`
- Update changelog and project for rc.2 release

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1611)