### PR TITLE
Fixes regression on passing custom baseurl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project does adheres to [Semantic Versioning](https://semver.org/spec/v
 
 ## [Unreleased]
 
+## [5.0.0-rc.3] - 2023-01-16
+
+### Changed
+
+- Fixed a regression where passing custom base url would not be reflected in the requests.
+
 ## [5.0.0-rc.2] - 2023-01-11
 
 ### Changed

--- a/src/Microsoft.Graph/GraphServiceClient.cs
+++ b/src/Microsoft.Graph/GraphServiceClient.cs
@@ -32,12 +32,9 @@ namespace Microsoft.Graph
         /// </summary>
         /// <param name="requestAdapter">The custom <see cref="IRequestAdapter"/> to be used for making requests</param>
         /// <param name="baseUrl">The base service URL. For example, "https://graph.microsoft.com/v1.0"</param>
-        public GraphServiceClient(IRequestAdapter requestAdapter, string baseUrl = null): base(requestAdapter)
+        public GraphServiceClient(IRequestAdapter requestAdapter, string baseUrl = null): base(InitializeRequestAdapterWithBaseUrl(requestAdapter,baseUrl))
         {
             this.RequestAdapter = requestAdapter;
-            if (!string.IsNullOrEmpty(baseUrl)) {
-                this.RequestAdapter.BaseUrl = baseUrl;
-            }
         }
 
         /// <summary>
@@ -94,6 +91,16 @@ namespace Microsoft.Graph
             {
                 return new BatchRequestBuilder(this.RequestAdapter);
             }
+        }
+        
+        private static IRequestAdapter InitializeRequestAdapterWithBaseUrl(IRequestAdapter requestAdapter, string baseUrl)
+        {
+            if (!string.IsNullOrEmpty(baseUrl))
+            {
+                requestAdapter.BaseUrl = baseUrl;
+            }
+
+            return requestAdapter;
         }
     }
 }

--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -25,12 +25,9 @@
     <!-- VersionPrefix minor version should not be set when the change comes from the generator. It will be updated automatically. -->
     <!-- VersionPrefix minor version must be manually set when making manual changes to code. -->
     <!-- VersionPrefix major and patch versions must be manually set. -->
-    <VersionSuffix>rc.2</VersionSuffix>
+    <VersionSuffix>rc.3</VersionSuffix>
     <PackageReleaseNotes>
-- Release candidate 2
-- [Breaking] Renames `CreateXXXRequestInformation` methods to `ToXXXRequestInformation
-- Adds `IAuthenticationProvider` parameter to GraphServiceClient constructor taking a httpClient instance.
-- Latest metadata updates from 12th January 2023 snapshot
+        - Fixed a regression where passing custom base url would not be reflected in the requests.
     </PackageReleaseNotes>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/tests/Microsoft.Graph.DotnetCore.Test/Models/GraphServiceClientTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Models/GraphServiceClientTests.cs
@@ -1,0 +1,38 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using Microsoft.Kiota.Abstractions.Authentication;
+using Xunit;
+
+namespace Microsoft.Graph.DotnetCore.Test.Models;
+
+public class GraphServiceClientTests
+{
+    [Fact]
+    public void InitializesClient()
+    {
+        // Arrange
+        var graphClient = new GraphServiceClient(new AnonymousAuthenticationProvider());
+        
+        // Act
+        var userRequestInformation = graphClient.Me.ToGetRequestInformation();
+        
+        // Assert
+        Assert.Contains("https://graph.microsoft.com", userRequestInformation.URI.OriginalString);
+    }
+    
+    [Fact]
+    public void InitializesClientWithCustomBaseUrl()
+    {
+        // Arrange
+        var customBaseUrl = "https://graph.microsoft-ppe.com";
+        var graphClient = new GraphServiceClient(new AnonymousAuthenticationProvider(), customBaseUrl);
+        
+        // Act
+        var userRequestInformation = graphClient.Me.ToGetRequestInformation();
+        
+        // Assert
+        Assert.Contains(customBaseUrl, userRequestInformation.URI.OriginalString);
+    }
+}


### PR DESCRIPTION
This PR closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1613

It addresses a regression introduced by adding the baseurl to the `PathParameters` collection of the GraphServiceClient that prevented the correct propagation of custom base urls passed to the constructor. 
This PR therefore ensures the `RequestAdapter` is properly initialized with the custom base url to ensure the correct url is passed to the PathParameters collection.