### PR TITLE
Adds derived BatchRequestBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,8 @@ If you are looking to build the library locally for the purposes of contributing
 - Run `dotnet restore` from the command line in your package directory
 - Run `nuget restore` and `msbuild` from CLI or run Build from Visual Studio to restore Nuget packages and build the project
 
+> Due to long file names you may need to run `git config --system core.longpaths true` before cloning the repo to your system.
+
 ## License
 
 Copyright (c) Microsoft Corporation. All Rights Reserved. Licensed under the MIT [license](LICENSE.txt). See [Third Party Notices](https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/master/THIRD%20PARTY%20NOTICES) for information on the packages referenced via NuGet.

--- a/src/Microsoft.Graph/Extensions/CustomBatchRequestBuilder.cs
+++ b/src/Microsoft.Graph/Extensions/CustomBatchRequestBuilder.cs
@@ -1,0 +1,60 @@
+﻿// ------------------------------------------------------------------------------
+//  Copyright (c) Microsoft Corporation.  All Rights Reserved.  Licensed under the MIT License.  See License in the project root for license information.
+// ------------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Graph.Models.ODataErrors;
+using Microsoft.Kiota.Abstractions;
+using Microsoft.Kiota.Abstractions.Serialization;
+
+namespace Microsoft.Graph.Requests;
+
+public class CustomBatchRequestBuilder: Core.Requests.BatchRequestBuilder
+{
+    /// <summary>
+    /// Constructs a new BatchRequestBuilder.
+    /// </summary>
+    /// <param name="requestAdapter">The request adapter to use to execute the requests.</param>
+    public CustomBatchRequestBuilder(IRequestAdapter requestAdapter): base(requestAdapter)
+    {
+        _ = requestAdapter ?? throw new ArgumentNullException(nameof(requestAdapter));
+    }
+
+    /// <summary>
+    /// Sends out the <see cref="BatchRequestContent"/> using the POST method
+    /// </summary>
+    /// <param name="batchRequestContent">The <see cref="BatchRequestContent"/> for the request</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/> to use for cancelling requests</param>
+    /// <param name="errorMappings">The error mappings for using to handle errors in batch request</param>
+    /// <returns></returns>
+    public new Task<BatchResponseContent> PostAsync(BatchRequestContent batchRequestContent, CancellationToken cancellationToken = default, Dictionary<string, ParsableFactory<IParsable>> errorMappings = null)
+    {
+        var batchErrorMappings = errorMappings ?? new Dictionary<string, ParsableFactory<IParsable>> {
+            {"4XX", ODataError.CreateFromDiscriminatorValue},
+            {"5XX", ODataError.CreateFromDiscriminatorValue},
+        };
+
+        return base.PostAsync(batchRequestContent, cancellationToken, batchErrorMappings);
+    }
+
+    /// <summary>
+    /// Sends out the <see cref="BatchRequestContentCollection"/> using the POST method
+    /// </summary>
+    /// <param name="batchRequestContentCollection">The <see cref="BatchRequestContentCollection"/> for the request</param>
+    /// <param name="cancellationToken"><see cref="CancellationToken"/> to use for cancelling requests</param>
+    /// <param name="errorMappings">The error mappings for using to handle errors in batch request</param>
+    /// <returns></returns>
+    public new Task<BatchResponseContentCollection> PostAsync(BatchRequestContentCollection batchRequestContentCollection, CancellationToken cancellationToken = default, Dictionary<string, ParsableFactory<IParsable>> errorMappings = null)
+    {
+        var batchErrorMappings = errorMappings ?? new Dictionary<string, ParsableFactory<IParsable>> {
+            {"4XX", ODataError.CreateFromDiscriminatorValue},
+            {"5XX", ODataError.CreateFromDiscriminatorValue},
+        };
+
+        return base.PostAsync(batchRequestContentCollection, cancellationToken, batchErrorMappings);
+        }
+}

--- a/src/Microsoft.Graph/GraphServiceClient.cs
+++ b/src/Microsoft.Graph/GraphServiceClient.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Graph
     using System.Collections.Generic;
     using System.Linq;
     using System.Reflection;
+    using Microsoft.Graph.Requests;
     using Microsoft.Graph.Core.Requests;
     using Microsoft.Kiota.Abstractions.Authentication;
     using Microsoft.Kiota.Authentication.Azure;
@@ -89,7 +90,7 @@ namespace Microsoft.Graph
         {
             get
             {
-                return new BatchRequestBuilder(this.RequestAdapter);
+                return new CustomBatchRequestBuilder(this.RequestAdapter);
             }
         }
         


### PR DESCRIPTION
This PR depends on https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/637

Adds a derived BatchRequestBuilder to allow passing for errormappings to allow for consistent errors. and closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1782

Also closes https://github.com/microsoftgraph/msgraph-sdk-dotnet/issues/1784

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1794)