### PR TITLE
Update upgrade-to-v5.md

### DIFF
--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -244,6 +244,19 @@ var groupDriveId = driveItem.Id;
 var children = await graphServiceClient.Drives[groupDriveId].Items["itemId"].Children.GetAsync();
 ```
 
+#### Upload a small file with conflictBehavior set
+
+To upload a small file (remember the size should not exceed 4mb according to the [docs](https://learn.microsoft.com/en-us/graph/api/driveitem-put-content?view=graph-rest-1.0&tabs=http)) and at the same time, set the `conflictBehavior` [instance attribute](https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0#instance-attributes) you'll need to do it this way:
+
+```cs
+var requestInformation = graphClient.Drives[drive.Id.ToString()].Root.ItemWithPath("MediaMeta.xml").Content.ToPutRequestInformation(file);
+requestInformation.URI = new Uri(requestInformation.URI.OriginalString +"?@microsoft.graph.conflictBehavior=rename");
+
+var result = await graphClient.RequestAdapter.SendAsync<DriveItem>(requestInformation, DriveItem.CreateFromDiscriminatorValue);
+```
+
+To [upload large files](https://learn.microsoft.com/en-us/graph/sdks/large-file-upload?view=graph-rest-1.0&tabs=csharp#upload-large-file-to-onedrive), the method is slightly different.
+
 ## New Features
 
 ### Backing Store


### PR DESCRIPTION
Fixes #1830 

### Changes proposed in this pull request

Add an example on how to add `conflictBehavior` when uploading small files. The example in the official docs don't cover this, it only covers how to upload large files and the method used there to set the property doesn't work for uploading small files.

### Other links
- https://learn.microsoft.com/en-us/graph/sdks/large-file-upload?view=graph-rest-1.0&tabs=csharp#upload-large-file-to-onedrive
- https://learn.microsoft.com/en-us/graph/api/resources/driveitem?view=graph-rest-1.0#instance-attributes
- https://learn.microsoft.com/en-us/graph/api/driveitem-put-content?view=graph-rest-1.0&tabs=http

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1864)