### PR TITLE
- add branch protection policy file

### DIFF
--- a/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
@@ -64,30 +64,3 @@ configuration:
     restrictsPushes: false
     # Restrict who can dismiss pull request reviews
     restrictsReviewDismissals: false
-
-  - branchNamePattern: feature/5.0
-    # Specifies whether this branch can be deleted. boolean
-    allowsDeletions: false
-    # Specifies whether forced pushes are allowed on this branch. boolean
-    allowsForcePushes: false
-    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: true
-    # Specifies whether admins can overwrite branch protection. boolean
-    isAdminEnforced: false
-    # Specifies the number of pull request reviews before merging. int (0-6)
-    requiredApprovingReviewsCount: 1
-    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: true
-    # Are commits required to be signed. boolean
-    requiresCommitSignatures: false
-    # Are merge commits prohibited from being pushed to this branch. boolean
-    requiresLinearHistory: false
-    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusChecks:
-    - build
-    # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
-    requiresStrictStatusChecks: true
-    # Restrict who can push to matching branches
-    restrictsPushes: false
-    # Restrict who can dismiss pull request reviews
-    restrictsReviewDismissals: false

--- a/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
@@ -16,15 +16,13 @@ configuration:
     # Specifies whether forced pushes are allowed on this branch. boolean
     allowsForcePushes: false
     # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: false
+    dismissStaleReviews: true
     # Specifies whether admins can overwrite branch protection. boolean
     isAdminEnforced: false
-    # Specifies whether approving reviews are required to update matching branches. boolean
-    requiresApprovingReviews: true
     # Specifies the number of pull request reviews before merging. int (0-6)
     requiredApprovingReviewsCount: 1
     # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: false
+    requireCodeOwnersReview: true
     # Are commits required to be signed. boolean
     requiresCommitSignatures: false
     # Are merge commits prohibited from being pushed to this branch. boolean
@@ -36,7 +34,7 @@ configuration:
     - build
     - license/cla
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
-    requiresStrictStatusChecks: false
+    requiresStrictStatusChecks: true
     # Restrict who can push to matching branches
     restrictsPushes: false
     # Restrict who can dismiss pull request reviews
@@ -51,8 +49,6 @@ configuration:
     dismissStaleReviews: true
     # Specifies whether admins can overwrite branch protection. boolean
     isAdminEnforced: false
-    # Specifies whether approving reviews are required to update matching branches. boolean
-    requiresApprovingReviews: true
     # Specifies the number of pull request reviews before merging. int (0-6)
     requiredApprovingReviewsCount: 1
     # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
@@ -79,15 +75,13 @@ configuration:
     # Specifies whether forced pushes are allowed on this branch. boolean
     allowsForcePushes: false
     # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
-    dismissStaleReviews: false
+    dismissStaleReviews: true
     # Specifies whether admins can overwrite branch protection. boolean
     isAdminEnforced: false
-    # Specifies whether approving reviews are required to update matching branches. boolean
-    requiresApprovingReviews: true
     # Specifies the number of pull request reviews before merging. int (0-6)
     requiredApprovingReviewsCount: 1
     # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
-    requireCodeOwnersReview: false
+    requireCodeOwnersReview: true
     # Are commits required to be signed. boolean
     requiresCommitSignatures: false
     # Are merge commits prohibited from being pushed to this branch. boolean
@@ -98,7 +92,7 @@ configuration:
     requiredStatusCheckContexts:
     - build
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
-    requiresStrictStatusChecks: false
+    requiresStrictStatusChecks: true
     # Restrict who can push to matching branches
     restrictsPushes: false
     # Restrict who can dismiss pull request reviews

--- a/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
@@ -28,7 +28,7 @@ configuration:
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiresStatusChecks: true
+    requiredStatusChecks: true
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusCheckContexts:
     - build
@@ -58,7 +58,7 @@ configuration:
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiresStatusChecks: true
+    requiredStatusChecks: true
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusCheckContexts:
     - build
@@ -87,7 +87,7 @@ configuration:
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiresStatusChecks: true
+    requiredStatusChecks: true
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusCheckContexts:
     - build

--- a/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
@@ -1,0 +1,105 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# File initially created using https://github.com/MIchaelMainer/policyservicetoolkit/blob/main/branch_protection_export.ps1.
+
+name: msgraph-sdk-dotnet-branch-protection
+description: Branch protection policy for the msgraph-sdk-dotnet repository
+resource: repository
+configuration:
+  branchProtectionRules:
+
+  # The following GitHub PolicyService properties are not supported: whoCanDismissReviews and whoCanPush
+  - branchNamePattern: master
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: false
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Specifies whether approving reviews are required to update matching branches. boolean
+    requiresApprovingReviews: true
+    # Specifies the number of pull request reviews before merging. int (0-6)
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: false
+    # Are commits required to be signed. boolean
+    requiresCommitSignatures: false
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: false
+    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiresStatusChecks: true
+    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiredStatusCheckContexts:
+    - build
+    - license/cla
+    # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
+    requiresStrictStatusChecks: false
+    # Restrict who can push to matching branches
+    restrictsPushes: false
+    # Restrict who can dismiss pull request reviews
+    restrictsReviewDismissals: false
+
+  - branchNamePattern: dev
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: true
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Specifies whether approving reviews are required to update matching branches. boolean
+    requiresApprovingReviews: true
+    # Specifies the number of pull request reviews before merging. int (0-6)
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: true
+    # Are commits required to be signed. boolean
+    requiresCommitSignatures: false
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: false
+    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiresStatusChecks: true
+    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiredStatusCheckContexts:
+    - build
+    # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
+    requiresStrictStatusChecks: true
+    # Restrict who can push to matching branches
+    restrictsPushes: false
+    # Restrict who can dismiss pull request reviews
+    restrictsReviewDismissals: false
+
+  - branchNamePattern: feature/5.0
+    # Specifies whether this branch can be deleted. boolean
+    allowsDeletions: false
+    # Specifies whether forced pushes are allowed on this branch. boolean
+    allowsForcePushes: false
+    # Specifies whether new commits pushed to the matching branches dismiss pull request review approvals. boolean
+    dismissStaleReviews: false
+    # Specifies whether admins can overwrite branch protection. boolean
+    isAdminEnforced: false
+    # Specifies whether approving reviews are required to update matching branches. boolean
+    requiresApprovingReviews: true
+    # Specifies the number of pull request reviews before merging. int (0-6)
+    requiredApprovingReviewsCount: 1
+    # Require review from Code Owners. Requires requiredApprovingReviewsCount. boolean
+    requireCodeOwnersReview: false
+    # Are commits required to be signed. boolean
+    requiresCommitSignatures: false
+    # Are merge commits prohibited from being pushed to this branch. boolean
+    requiresLinearHistory: false
+    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiresStatusChecks: true
+    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
+    requiredStatusCheckContexts:
+    - build
+    # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
+    requiresStrictStatusChecks: false
+    # Restrict who can push to matching branches
+    restrictsPushes: false
+    # Restrict who can dismiss pull request reviews
+    restrictsReviewDismissals: false

--- a/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
@@ -25,6 +25,8 @@ configuration:
     requireCodeOwnersReview: true
     # Are commits required to be signed. boolean
     requiresCommitSignatures: false
+    # Are conversations required to be resolved before merging? boolean
+    requiresConversationResolution: true
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
@@ -53,11 +55,14 @@ configuration:
     requireCodeOwnersReview: true
     # Are commits required to be signed. boolean
     requiresCommitSignatures: false
+    # Are conversations required to be resolved before merging? boolean
+    requiresConversationResolution: true
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
     requiredStatusChecks:
     - build
+    - license/cla
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
     requiresStrictStatusChecks: true
     # Restrict who can push to matching branches

--- a/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
+++ b/.github/policies/msgraph-sdk-dotnet-branch-protection.yml
@@ -28,9 +28,7 @@ configuration:
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusChecks: true
-    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusCheckContexts:
+    requiredStatusChecks:
     - build
     - license/cla
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
@@ -58,9 +56,7 @@ configuration:
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusChecks: true
-    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusCheckContexts:
+    requiredStatusChecks:
     - build
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
     requiresStrictStatusChecks: true
@@ -87,9 +83,7 @@ configuration:
     # Are merge commits prohibited from being pushed to this branch. boolean
     requiresLinearHistory: false
     # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusChecks: true
-    # Requires requiresStrictStatusChecks. Values can be any string, but if the value does not correspond to any existing status check, the status check will be stuck on pending for status since nothing exists to push an actual status
-    requiredStatusCheckContexts:
+    requiredStatusChecks:
     - build
     # The docs conflict. Are branches required to be up to date before merging. Or Require status checks to pass before merging
     requiresStrictStatusChecks: true


### PR DESCRIPTION
Initial commit [generated from the existing UI set branch policies using GH CLI](https://github.com/MIchaelMainer/policyservicetoolkit/blob/main/branch_protection_export.ps1). 

Carefully review the policy for additions and changes that should be added here. Review subsequent commits for changes to policy. 

> IMPORTANT: Policy changes can be disruptive to workflows.

- [x] add missing policies