### PR TITLE
Now support logo uploads with custom Content-Type header

### DIFF
--- a/src/Microsoft.Graph/Generated/Applications/Item/Logo/LogoRequestBuilder.cs
+++ b/src/Microsoft.Graph/Generated/Applications/Item/Logo/LogoRequestBuilder.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Graph.Applications.Item.Logo {
             };
             requestInfo.SetStreamContent(body);
             if (requestConfiguration != null) {
+                requestInfo.Headers.Remove("Content-Type", "application/octet-stream");
                 var requestConfig = new LogoRequestBuilderPutRequestConfiguration();
                 requestConfiguration.Invoke(requestConfig);
                 requestInfo.AddRequestOptions(requestConfig.Options);


### PR DESCRIPTION
Fixes #1951 

### Changes proposed in this pull request
- Remove the added `application/octet-stream` headers from a logo PUT request if a custom LogoRequestBuilderPutRequestConfiguration is provided.

###### Microsoft Reviewers: [Open in CodeFlow](https://portal.fabricbot.ms/api/codeflow?pullrequest=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/1952)