### PR TITLE
Update upgrade-to-v5.md to include difference between non-OData and OData query parameter values

### DIFF
--- a/docs/upgrade-to-v5.md
+++ b/docs/upgrade-to-v5.md
@@ -130,6 +130,49 @@ var groups = await graphServiceClient
     });
 ```
 
+### Query Parameter Values
+
+Standard Query parameters such as `Select`, `Search` or `Filter` now uses the OData standard with the `$` prefix.
+
+This can break your requests if you do not adapt your parameter values to take this into account.
+
+Example for SharePoint searches:
+
+```cs
+//Valid
+var sites = await graphServiceClient
+                .Sites
+                .GetAsync(requestConfiguration =>
+                {
+                  requestConfiguration.QueryParameters.Search = "\"a1\""; //Quotes are escaped
+                });
+
+//Invalid
+var sites = await graphServiceClient
+                .Sites
+                .GetAsync(requestConfiguration =>
+                {
+                  requestConfiguration.QueryParameters.Search = "a1"; // Numbers not accepted without quotes in $search. Returns an OData exception.
+                });
+
+//Valid
+var allSites = await graphServiceClient
+                .Sites
+                .GetAsync(requestConfiguration =>
+                {
+                  requestConfiguration.QueryParameters.Search = "\"id=*\""; // Select all on the id property
+                });
+
+//Invalid
+var allSites = await graphServiceClient
+                .Sites
+                .GetAsync(requestConfiguration =>
+                {
+                  requestConfiguration.QueryParameters.Search = "\"*\""; // $search="*" returns an empty array
+                });
+```
+To make sure that your conversion is correct verify your query parameters in the [Microsoft Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer) before running your code. Also make sure that special characters are either **escaped** or **URL encoded**.
+
 ### Per-Request Options
 To pass per-request options to the default http middleware to configure actions like redirects and retries, this can be done using the `requestConfiguration` by adding an `IRequestOption` instance to the `Options` collection. For example, adding a `RetryHandlerOption` instance to configure the retry handler option as below.
 


### PR DESCRIPTION
<!-- Read me before you submit this pull request

First off, thank you for opening this pull request! We do appreciate it.

The requests and models for this client library are generated. We won't be accepting pull requests for those code files. With that said, we do appreciate
it when you open pull requests with the proposed file changes as we'll use that to help guide us in updating our template files.

-->

<!-- Optional. Set the issues that this pull request fixes. Delete 'Fixes #' if there isn't an issue associated with this pull request. -->
Fixes #1884 

<!-- Required. Provide specifics about what the changes are and why you're proposing these changes. -->
### Changes proposed in this pull request
- Updates the breaking change documentation of the SDK V5. It is the version that introduces the use of  the standard OData query parameters(`$search`, `$select`). These are behaving differently than the query parameters in the previous versions. However this change of behaviour is not documented in this repo or the official MS docs documentation.
- This PR aims to warn the users of the above issue and give some advice on what they can do avoid being blocked by it.

<!-- Optional. Provide related links. This might be other pull requests, code files, StackOverflow posts. Delete this section if it is not used. -->
### Other links
- [MS Docs documentation on how to search for a site](https://learn.microsoft.com/en-us/graph/api/site-search?view=graph-rest-1.0&tabs=http)
  - The provided example does not work in the V5 SDK. Neither is the HTTP example showing how to do queries with `$search`
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/2275)