### PR TITLE
[Compliance] Pipeline compliance

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -90,7 +90,7 @@ extends:
         - task: DotNetCoreCLI@2
           displayName: 'Build test project'
           inputs:
-            projects: '$(Build.SourcesDirectory)\tests\Microsoft.Graph.DotnetCore.Test.csproj'
+            projects: '$(Build.SourcesDirectory)\tests\Microsoft.Graph.DotnetCore.Test\Microsoft.Graph.DotnetCore.Test.csproj'
             arguments: '-c $(BuildConfiguration) --no-incremental --no-restore'
         - task: DotNetCoreCLI@2
           displayName: 'run tests'

--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -1,203 +1,277 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
-
 name: $(BuildDefinitionName)_$(SourceBranchName)_$(Date:yyyyMMdd)$(Rev:.r)
 trigger:
   branches:
     include:
-      - master
+    - master
 pr: none
-
-pool:
-  vmImage: 'windows-latest'
-
 variables:
   BuildConfiguration: 'release'
+resources:
+  repositories:
+  - repository: 1ESPipelineTemplates
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    pool:
+      name: Azure-Pipelines-1ESPT-ExDShared
+      image: windows-latest
+      os: windows
+    sdl:
+      git: # Customize checkout to enable longpaths in git for the paralled sdl https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/sourceanalysisstage
+        longpaths: true
+      baseline:
+        baselineFile: $(Build.SourcesDirectory)\guardian\SDL\.gdnbaselines
+      suppression:
+        suppressionFile: $(Build.SourcesDirectory)\guardian\SDL\.gdnsuppress
+      binskim: 
+        enabled: false
+        justificationForDisabling: 'Binskim is consistently crashing with this error message : System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.'
+    customBuildTags:
+    - ES365AIMigrationTooling
+    stages:
+    - stage: build
+      jobs:
+      - job: build
+        timeoutInMinutes: 120
+        templateContext:
+          outputs:
+          - output: pipelineArtifact
+            displayName: 'Publish Artifact: Microsoft.Graph.nupkg and release pipeline scripts'
+            artifactName: ReadyForReleasePipeline
+            targetPath: '$(Build.ArtifactStagingDirectory)'
+        steps:
+        - pwsh: git config --system core.longpaths true
+          displayName: 'Enable long paths in git'
+        - checkout: self
+        - task: UseDotNet@2
+          displayName: 'Use .NET 8.x sdk'
+          inputs:
+            packageType: sdk
+            version: 8.x
+        - task: UseDotNet@2
+          displayName: 'Use .NET 6.x (for code signing tasks)'
+          inputs:
+            packageType: sdk
+            version: 6.x
+        - task: DotNetCoreCLI@2
+          displayName: 'dotnet restore'
+          inputs:
+            command: restore
+            projects: '**/*.csproj'
+        - powershell: |
+            # This allows us to not have to checkin .csproj files with DelaySign and SignAssembly set to to true. If the flag is set,
+            # then project is not debuggable with SignAssembly set to true.
+            # Assumption: working directory is /src/
+            $csprojPaths = @(".\Microsoft.Graph\Microsoft.Graph.csproj")
+            foreach ($csprojPath in $csprojPaths) {
+                $doc = New-Object System.Xml.XmlDocument
+                $doc.Load($csprojPath)
+                # Set the DelaySign element to 'true' so that delay signing is set.
+                $delaySign = $doc.SelectSingleNode("//DelaySign");
+                $delaySign.'#text'= "true"
+                # Set the SignAssembly element to 'true' so that we can sign the assemblies.
+                $signAssembly = $doc.SelectSingleNode("//SignAssembly");
+                $signAssembly.'#text'= "true"
+                $doc.Save($csprojPath);
+            }
+            Write-Host "Updated the .csproj files so that we can sign the built assemblies."
+          workingDirectory: src
+          displayName: 'Set project ready to sign'
+        - task: DotNetCoreCLI@2
+          displayName: 'Build project'
+          inputs:
+            projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.csproj'
+            arguments: '-c $(BuildConfiguration) --no-incremental --no-restore'
+        - task: DotNetCoreCLI@2
+          displayName: 'Build test project'
+          inputs:
+            projects: '$(Build.SourcesDirectory)\tests\Microsoft.Graph.DotnetCore.Test.csproj'
+            arguments: '-c $(BuildConfiguration) --no-incremental --no-restore'
+        - task: DotNetCoreCLI@2
+          displayName: 'run tests'
+          inputs:
+            command: 'test'
+            arguments: '--configuration $(BuildConfiguration) --verbosity normal --no-build'
+        - task: PowerShell@2
+          displayName: 'Validate updated version'
+          inputs:
+            targetType: filePath
+            filePath: '$(Build.SourcesDirectory)\scripts\ValidateUpdatedNugetVersion.ps1'
+            arguments: '-packageName "Microsoft.Graph" -projectPath "$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.csproj"'
+            pwsh: true
+          enabled: true
+        - task: EsrpCodeSigning@3
+          displayName: 'ESRP DLL Strong Name (Microsoft.Graph)'
+          inputs:
+            ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+            FolderPath: src/Microsoft.Graph/bin/release
+            Pattern: Microsoft.Graph.dll
+            signConfigType: inlineSignParams
+            inlineOperation: |
+              [
+                  {
+                      "keyCode": "CP-233863-SN",
+                      "operationSetCode": "StrongNameSign",
+                      "parameters": [],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  },
+                  {
+                      "keyCode": "CP-233863-SN",
+                      "operationSetCode": "StrongNameVerify",
+                      "parameters": [],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  }
+              ]
+            SessionTimeout: 20
+        - task: EsrpCodeSigning@3
+          displayName: 'ESRP DLL CodeSigning (Microsoft.Graph)'
+          inputs:
+            ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+            FolderPath: src/Microsoft.Graph/bin/release
+            Pattern: Microsoft.Graph.dll
+            signConfigType: inlineSignParams
+            inlineOperation: |
+              [
+                  {
+                      "keyCode": "CP-230012",
+                      "operationSetCode": "SigntoolSign",
+                      "parameters": [
+                          {
+                              "parameterName": "OpusName",
+                              "parameterValue": "Microsoft"
+                          },
+                          {
+                              "parameterName": "OpusInfo",
+                              "parameterValue": "http://www.microsoft.com"
+                          },
+                          {
+                              "parameterName": "FileDigest",
+                              "parameterValue": "/fd \"SHA256\""
+                          },
+                          {
+                              "parameterName": "PageHash",
+                              "parameterValue": "/NPH"
+                          },
+                          {
+                              "parameterName": "TimeStamp",
+                              "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
+                          }
+                      ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  },
+                  {
+                      "keyCode": "CP-230012",
+                      "operationSetCode": "SigntoolVerify",
+                      "parameters": [],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  }
+              ]
+            SessionTimeout: 20
+        - powershell: |
+            dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph/Microsoft.Graph.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
+          env:
+            BUILD_CONFIGURATION: $(BuildConfiguration)
+          displayName: dotnet pack
+        - task: EsrpCodeSigning@3
+          displayName: 'ESRP NuGet CodeSigning'
+          inputs:
+            ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
+            FolderPath: '$(Build.ArtifactStagingDirectory)'
+            Pattern: '*nupkg'
+            signConfigType: inlineSignParams
+            inlineOperation: |
+              [
+                  {
+                      "keyCode": "CP-401405",
+                      "operationSetCode": "NuGetSign",
+                      "parameters": [ ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  },
+                  {
+                      "keyCode": "CP-401405",
+                      "operationSetCode": "NuGetVerify",
+                      "parameters": [ ],
+                      "toolName": "sign",
+                      "toolVersion": "1.0"
+                  }
+              ]
+            SessionTimeout: 20
+        - task: CopyFiles@2
+          displayName: 'Copy release scripts to artifact staging directory'
+          inputs:
+            SourceFolder: '$(Build.SourcesDirectory)'
+            Contents: 'scripts\**'
+            TargetFolder: '$(Build.ArtifactStagingDirectory) '
 
-steps:
-- pwsh: git config --system core.longpaths true
-
-- checkout: self
-
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
-  displayName: 'Run CredScan'
-  inputs:
-    toolMajorVersion: 'V2'
-    scanFolder: '$(Build.SourcesDirectory)'
-    debugMode: false
-
-- task: UseDotNet@2
-  displayName: 'Use .NET sdk'
-  inputs:
-    packageType: sdk
-    version: 6.x
-
-- task: UseDotNet@2
-  displayName: 'Use .NET 2.x (for code signing tasks)'
-  inputs:
-    packageType: sdk
-    version: 2.x
-    
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet restore'
-  inputs:
-    command: restore
-    projects: '**/*.csproj'
-
-- powershell: |
-   # This allows us to not have to checkin .csproj files with DelaySign and SignAssembly set to to true. If the flag is set,
-   # then project is not debuggable with SignAssembly set to true.
-   # Assumption: working directory is /src/
-
-   $csprojPaths = @(".\Microsoft.Graph\Microsoft.Graph.csproj")
-
-   foreach ($csprojPath in $csprojPaths) {
-
-       $doc = New-Object System.Xml.XmlDocument
-       $doc.Load($csprojPath)
-
-       # Set the DelaySign element to 'true' so that delay signing is set.
-       $delaySign = $doc.SelectSingleNode("//DelaySign");
-       $delaySign.'#text'= "true"
-
-       # Set the SignAssembly element to 'true' so that we can sign the assemblies.
-       $signAssembly = $doc.SelectSingleNode("//SignAssembly");
-       $signAssembly.'#text'= "true"
-
-       $doc.Save($csprojPath);
-   }
-
-   Write-Host "Updated the .csproj files so that we can sign the built assemblies."
-  workingDirectory: src
-  displayName: 'Set project ready to sign'
-
-- task: DotNetCoreCLI@2
-  displayName: 'dotnet build'
-  inputs:
-    projects: '$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.csproj'
-    arguments: '-c $(BuildConfiguration) --no-incremental'
-
-- task: DotNetCoreCLI@2
-  displayName: 'run tests'
-  inputs:
-    command: 'test'
-    arguments: '--configuration $(BuildConfiguration) --verbosity normal'
-
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP DLL Strong Name (Microsoft.Graph)'
-  inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-    FolderPath: src/Microsoft.Graph/bin/release
-    Pattern: Microsoft.Graph.dll
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-         {
-             "keyCode": "CP-233863-SN",
-             "operationSetCode": "StrongNameSign",
-             "parameters": [],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-233863-SN",
-             "operationSetCode": "StrongNameVerify",
-             "parameters": [],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
-     ]
-    SessionTimeout: 20
-
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP DLL CodeSigning (Microsoft.Graph)'
-  inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-    FolderPath: src/Microsoft.Graph/bin/release
-    Pattern: Microsoft.Graph.dll
-    signConfigType: inlineSignParams
-    inlineOperation: |
-     [
-         {
-             "keyCode": "CP-230012",
-             "operationSetCode": "SigntoolSign",
-             "parameters": [
-                 {
-                     "parameterName": "OpusName",
-                     "parameterValue": "Microsoft"
-                 },
-                 {
-                     "parameterName": "OpusInfo",
-                     "parameterValue": "http://www.microsoft.com"
-                 },
-                 {
-                     "parameterName": "FileDigest",
-                     "parameterValue": "/fd \"SHA256\""
-                 },
-                 {
-                     "parameterName": "PageHash",
-                     "parameterValue": "/NPH"
-                 },
-                 {
-                     "parameterName": "TimeStamp",
-                     "parameterValue": "/tr \"http://rfc3161.gtm.corp.microsoft.com/TSS/HttpTspServer\" /td sha256"
-                 }
-             ],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         },
-         {
-             "keyCode": "CP-230012",
-             "operationSetCode": "SigntoolVerify",
-             "parameters": [],
-             "toolName": "sign",
-             "toolVersion": "1.0"
-         }
-     ]
-    SessionTimeout: 20
-
-# arguments are not parsed in DotNetCoreCLI@2 task for `pack` command, that's why we have a custom pack command here
-- powershell: |
-    dotnet pack $env:BUILD_SOURCESDIRECTORY/src/Microsoft.Graph/Microsoft.Graph.csproj /p:IncludeSymbols=true /p:SymbolPackageFormat=snupkg --no-build --output $env:BUILD_ARTIFACTSTAGINGDIRECTORY --configuration $env:BUILD_CONFIGURATION
-  env:
-    BUILD_CONFIGURATION: $(BuildConfiguration)
-  displayName: dotnet pack
-
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
-  displayName: 'ESRP NuGet CodeSigning'
-  inputs:
-    ConnectedServiceName: 'microsoftgraph ESRP CodeSign DLL and NuGet (AKV)'
-    FolderPath: '$(Build.ArtifactStagingDirectory)'
-    Pattern: '*nupkg'
-    signConfigType: inlineSignParams
-    inlineOperation: |
-          [
-              {
-                  "keyCode": "CP-401405",
-                  "operationSetCode": "NuGetSign",
-                  "parameters": [ ],
-                  "toolName": "sign",
-                  "toolVersion": "1.0"
-              },
-              {
-                  "keyCode": "CP-401405",
-                  "operationSetCode": "NuGetVerify",
-                  "parameters": [ ],
-                  "toolName": "sign",
-                  "toolVersion": "1.0"
-              }
-          ]
-
-    SessionTimeout: 20
-
-- task: CopyFiles@2
-  displayName: 'Copy release scripts to artifact staging directory'
-  inputs:
-    SourceFolder: '$(Build.SourcesDirectory)'
-    Contents: 'scripts\**'
-    TargetFolder: '$(Build.ArtifactStagingDirectory) '
-
-- task: PublishBuildArtifacts@1
-  displayName: 'Publish Artifact: Microsoft.Graph.nupkg and release pipeline scripts'
-  inputs:
-    ArtifactName: ReadyForReleasePipeline
+    - stage: deploy
+      condition: and(contains(variables['build.sourceBranch'], 'refs/heads/master'), succeeded())
+      dependsOn: build
+      jobs:
+        - deployment: deploy_nuget
+          pool:
+            name: Azure-Pipelines-1ESPT-ExDShared
+            os: windows
+            image: windows-latest
+          dependsOn: []
+          environment: nuget-org
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                - task: NuGetToolInstaller@1
+                  displayName: 'Use NuGet >=5.2.0'
+                  inputs:
+                    versionSpec: '>=5.2.0'
+                    checkLatest: true
+                - task: DownloadPipelineArtifact@2
+                  displayName: Download nupkg from artifacts
+                  inputs:
+                    artifact: ReadyForReleasePipeline
+                    source: current
+                - task: PowerShell@2
+                  displayName: 'Get Latest Commit SHA from repo'
+                  inputs:
+                    targetType: filePath
+                    filePath: '$(Pipeline.Workspace)\scripts\GetLatestCommitSHA.ps1'
+                    arguments: '-repo "msgraph-sdk-dotnet" -owner "microsoftgraph" -branchName "master"'
+                    pwsh: true
+                - task: PowerShell@2
+                  displayName: 'Extract release information to pipeline'
+                  inputs:
+                    targetType: 'filePath'
+                    filePath: $(Pipeline.Workspace)\scripts\GetNugetPackageVersion.ps1
+                    pwsh: true
+                    arguments: '-packageDirPath "$(Pipeline.Workspace)/"'
+                - task: 1ES.PublishNuget@1
+                  displayName: 'Push release to NuGet.org'
+                  inputs:
+                    command: push
+                    packageParentPath: '$(Pipeline.Workspace)'
+                    packagesToPush: '$(Pipeline.Workspace)\Microsoft.Graph.*.nupkg'
+                    nuGetFeedType: external
+                    publishFeedCredentials: 'microsoftgraph NuGet connection'
+                - task: GitHubRelease@1
+                  displayName: 'GitHub release (create)'
+                  inputs:
+                    gitHubConnection: 'Kiota_Release'
+                    target: $(Build.SourceVersion)
+                    tagSource: userSpecifiedTag
+                    tag: 'v$(VERSION_STRING)'
+                    title: '$(VERSION_STRING)'
+                    releaseNotesSource: inline
+                    assets: |
+                      !**/**
+                      $(Pipeline.Workspace)/Microsoft.Graph.*.*nupkg
+                    changeLogType: issueBased
+                    isPreRelease: '$(IS_PRE_RELEASE)'
+                    addChangeLog: true

--- a/guardian/SDL/.gdnbaselines
+++ b/guardian/SDL/.gdnbaselines
@@ -1,0 +1,51 @@
+{
+  "hydrated": false,
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/baselines",
+    "hydrationStatus": "This file does not contain identifying data. It is safe to check into your repo. To hydrate this file with identifying data, run `guardian hydrate --help` and follow the guidance."
+  },
+  "version": "1.0.0",
+  
+  "results": {
+    "d02d560dfa2b990239a116442fa49696a9f86107683300985856426fb4afa2a6": {
+      "signature": "d02d560dfa2b990239a116442fa49696a9f86107683300985856426fb4afa2a6",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    },
+    "ac3bfa7c3028669618563f9295b4746774a51880defa826dd9c5b51bdb8af319": {
+      "signature": "ac3bfa7c3028669618563f9295b4746774a51880defa826dd9c5b51bdb8af319",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    },
+    "ce5fb869bd8e8a1e75f5f4a54b7309cd16f76ce9af950bb2358da70269857142": {
+      "signature": "ce5fb869bd8e8a1e75f5f4a54b7309cd16f76ce9af950bb2358da70269857142",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    },
+    "d9e6949d68f096882005442a0619fd2aaa61192ae6ed3f6cc2b7572f4f9b6dc0": {
+      "signature": "d9e6949d68f096882005442a0619fd2aaa61192ae6ed3f6cc2b7572f4f9b6dc0",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    },
+    "390d21d9ca1233762b9b807625a7748863063253e1e7cf529266e5d328bd0f4c": {
+      "signature": "390d21d9ca1233762b9b807625a7748863063253e1e7cf529266e5d328bd0f4c",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    }
+  }
+}

--- a/guardian/SDL/.gdnsuppress
+++ b/guardian/SDL/.gdnsuppress
@@ -1,0 +1,57 @@
+{
+  "hydrated": false,
+  "properties": {
+    "helpUri": "https://eng.ms/docs/microsoft-security/security/azure-security/cloudai-security-fundamentals-engineering/security-integration/guardian-wiki/microsoft-guardian/general/suppressions",
+    "hydrationStatus": "This file does not contain identifying data. It is safe to check into your repo. To hydrate this file with identifying data, run `guardian hydrate --help` and follow the guidance."
+  },
+  "version": "1.0.0",
+  "suppressionSets": {
+    "default": {
+      "name": "default",
+      "createdDate": "2024-03-07 11:56:47Z",
+      "lastUpdatedDate": "2024-03-07 11:56:47Z"
+    }
+  },
+  "results": {
+    "d02d560dfa2b990239a116442fa49696a9f86107683300985856426fb4afa2a6": {
+      "signature": "d02d560dfa2b990239a116442fa49696a9f86107683300985856426fb4afa2a6",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    },
+    "ac3bfa7c3028669618563f9295b4746774a51880defa826dd9c5b51bdb8af319": {
+      "signature": "ac3bfa7c3028669618563f9295b4746774a51880defa826dd9c5b51bdb8af319",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    },
+    "ce5fb869bd8e8a1e75f5f4a54b7309cd16f76ce9af950bb2358da70269857142": {
+      "signature": "ce5fb869bd8e8a1e75f5f4a54b7309cd16f76ce9af950bb2358da70269857142",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    },
+    "d9e6949d68f096882005442a0619fd2aaa61192ae6ed3f6cc2b7572f4f9b6dc0": {
+      "signature": "d9e6949d68f096882005442a0619fd2aaa61192ae6ed3f6cc2b7572f4f9b6dc0",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    },
+    "390d21d9ca1233762b9b807625a7748863063253e1e7cf529266e5d328bd0f4c": {
+      "signature": "390d21d9ca1233762b9b807625a7748863063253e1e7cf529266e5d328bd0f4c",
+      "alternativeSignatures": [],
+      "memberOf": [
+        "default"
+      ],
+      "createdDate": "2024-03-07 11:56:47Z"
+    }
+  }
+}

--- a/scripts/GetNugetPackageVersion.ps1
+++ b/scripts/GetNugetPackageVersion.ps1
@@ -28,7 +28,12 @@ $nugetPackageName = (Get-ChildItem (Join-Path $packageDirPath *.nupkg) -Exclude 
 Write-Host "Found NuGet package: $nugetPackageName" -ForegroundColor Magenta
 
 ## Extracts the package version from nupkg file name.
-$packageVersion = $nugetPackageName -replace "^(.*?)\.((?:\.?[0-9]+){3,}(?:[-a-z]+)?)\.nupkg$", '$2'
+$packageVersion = $nugetPackageName.Replace("Microsoft.Graph.", "").Replace(".nupkg", "")
 
 Write-Host "##vso[task.setvariable variable=VERSION_STRING]$($packageVersion)";
 Write-Host "Updated the VERSION_STRING environment variable with the package version value '$packageVersion'." -ForegroundColor Green
+
+$isPrerelease = $packageVersion.Contains("preview")
+
+Write-Host "##vso[task.setvariable variable=IS_PRE_RELEASE]$($isPrerelease)";
+Write-Host "Updated the IS_PRE_RELEASE environment variable with the pre-release value '$isPrerelease'." -ForegroundColor Green

--- a/scripts/ValidateUpdatedNugetVersion.ps1
+++ b/scripts/ValidateUpdatedNugetVersion.ps1
@@ -1,0 +1,69 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.Synopsis
+    Gets the latest production release version of the specified NuGet package.
+
+.Description
+    Gets the NuGet package version of latest production release and compares the
+    version to the version set in the specified project file. If they match, this
+    script will fail and indicate that the version needs to be updated.
+
+.Parameter packageName
+    Specifies the package name of the package. For example, 'microsoft.kiota.abstractions'
+    is a valid package name.
+
+.Parameter projectPath
+    Specifies the path to the project file.
+#>
+
+Param(
+    [parameter(Mandatory = $true)]
+    [string]$packageName,
+
+    [parameter(Mandatory = $true)]
+    [string]$projectPath
+)
+
+[xml]$xmlDoc = Get-Content $projectPath
+
+# Assumption: VersionPrefix is set in the first property group.
+$versionPrefixString = $xmlDoc.Project.PropertyGroup[0].VersionPrefix
+if($xmlDoc.Project.PropertyGroup[0].VersionSuffix){
+    $versionPrefixString = $versionPrefixString + "-"  + $xmlDoc.Project.PropertyGroup[0].VersionSuffix
+}
+
+
+# System.Version, get the version prefix.
+$currentProjectVersion = [System.Management.Automation.SemanticVersion]"$versionPrefixString"
+
+# API is case-sensitive
+$packageName = $packageName.ToLower()
+$url = "https://api.nuget.org/v3/registration5-gz-semver2/$packageName/index.json"
+
+# Call the NuGet API for the package and get the current published version.
+Try {
+    $nugetIndex = Invoke-RestMethod -Uri $url -Method Get
+}
+Catch {
+    if ($_.ErrorDetails.Message && $_.ErrorDetails.Message.Contains("The specified blob does not exist.")) {
+        Write-Host "No package exists. You will probably be publishing $packageName for the first time."
+        Exit # exit gracefully
+    }
+    
+    Write-Host $_
+    Exit 1
+}
+
+$currentPublishedVersion = [System.Management.Automation.SemanticVersion]$nugetIndex.items[$nugetIndex.items.Count-1].upper
+
+# Validate that the version number has been updated.
+if ($currentProjectVersion -le $currentPublishedVersion) {
+
+    Write-Error "The current published version number, $currentPublishedVersion, and the version number `
+               in the csproj file, $currentProjectVersion, match. You must increment the version"
+}
+else {
+    Write-Host "Validated that the version has been updated from $currentPublishedVersion to $currentProjectVersion" -ForegroundColor Green
+}

--- a/src/Microsoft.Graph/Microsoft.Graph.csproj
+++ b/src/Microsoft.Graph/Microsoft.Graph.csproj
@@ -22,7 +22,7 @@
     <DelaySign>false</DelaySign>
     <AssemblyOriginatorKeyFile>35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <VersionPrefix>5.44.0</VersionPrefix>
+    <VersionPrefix>5.44.1</VersionPrefix>
     <!-- VersionPrefix minor version should not be set when the change comes from the generator. It will be updated automatically. -->
     <!-- VersionPrefix minor version must be manually set when making manual changes to code. -->
     <!-- VersionPrefix major and patch versions must be manually set. -->
@@ -36,7 +36,7 @@ https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/dev/CHANGELOG.md
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <NoWarn>$(NoWarn);NU5048;NETSDK1138</NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFrameworkVersion)' == 'net5.0'">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)','net5.0'))">
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">


### PR DESCRIPTION
Part of https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/issues/808

Changes include
- Move deployment to yaml configuration to deprecate old release management
- Use 1es compliant templates

Notes.
- Binskim is consistently crashing with the error `System.AccessViolationException: Attempted to read or write protected memory. This is often an indication that other memory is corrupt.` on the build. This has been disabled with the justification as documented at [here](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-pipeline-templates/features/sdlanalysis/disablingtools#s360-exception-process-and-approvals-for-disabled-tools)

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/2370)