### PR TITLE
fix: use directories for dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,25 @@
 version: 2
 updates:
 - package-ecosystem: nuget
-  directory: "/"
+  directories:
+    - "**/*"
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  groups:
+    kiota-dependencies:
+      patterns:
+        - "*kiota*"
+    xunit:
+      patterns:
+        - xunit*
+    coverlet:
+      patterns:
+        - coverlet*
+    mstest:
+      patterns:
+        - Microsoft.NET.Test.Sdk
+        - Microsoft.TestPlatform.ObjectModel
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/2576)