### PR TITLE
fix: updated the UploadSession model to implement IUploadSession

### DIFF
--- a/src/Microsoft.Graph/Extensions/UploadSession.cs
+++ b/src/Microsoft.Graph/Extensions/UploadSession.cs
@@ -1,0 +1,8 @@
+﻿namespace Microsoft.Graph.Models
+{
+    public partial class UploadSession : Microsoft.Graph.IUploadSession
+    {
+    }
+}
+
+

--- a/tests/Microsoft.Graph.DotnetCore.Test/Models/Extensions/UploadSessionTests.cs
+++ b/tests/Microsoft.Graph.DotnetCore.Test/Models/Extensions/UploadSessionTests.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Graph.Models;
+using Xunit;
+
+namespace Microsoft.Graph.DotnetCore.Test.Extensions;
+
+public class UploadSessionTests
+{
+    [Fact]
+    public void AddPublicEncryptionCertificate()
+    {
+        // arrange 
+        var uploadSession = new UploadSession();
+
+        // act
+        Assert.IsAssignableFrom<IUploadSession>(uploadSession);
+    }
+}


### PR DESCRIPTION
Related to https://github.com/microsoftgraph/msgraph-sdk-dotnet-core/pull/903 to resolve trimming warnings due to reflection used.

Depends on merge of https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/2649

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/2653)