### PR TITLE
fix(ci): route NuGet version check through CFS

### DIFF
--- a/.azure-pipelines/ci-build.yml
+++ b/.azure-pipelines/ci-build.yml
@@ -144,7 +144,7 @@ extends:
           inputs:
             targetType: filePath
             filePath: '$(Build.SourcesDirectory)\scripts\ValidateUpdatedNugetVersion.ps1'
-            arguments: '-packageName "Microsoft.Graph" -projectPath "$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.csproj"'
+            arguments: '-packageName "Microsoft.Graph" -projectPath "$(Build.SourcesDirectory)\src\Microsoft.Graph\Microsoft.Graph.csproj" -nugetConfigPath "$(Build.SourcesDirectory)\nuget.config"'
             pwsh: true
           enabled: true
         - task: EsrpCodeSigning@5

--- a/scripts/ValidateUpdatedNugetVersion.ps1
+++ b/scripts/ValidateUpdatedNugetVersion.ps1
@@ -40,7 +40,7 @@ $currentProjectVersion = [System.Management.Automation.SemanticVersion]"$version
 
 # API is case-sensitive
 $packageName = $packageName.ToLower()
-$url = "https://api.nuget.org/v3/registration5-gz-semver2/$packageName/index.json"
+$url = "https://azuresearch-usnc.nuget.org/query?q=packageid:$packageName&prerelease=true&semVerLevel=2.0.0"
 
 # Call the NuGet API for the package and get the current published version.
 Try {
@@ -56,7 +56,7 @@ Catch {
     Exit 1
 }
 
-$currentPublishedVersion = [System.Management.Automation.SemanticVersion]$nugetIndex.items[$nugetIndex.items.Count-1].upper
+$currentPublishedVersion = [System.Management.Automation.SemanticVersion]$nugetIndex.data[0].version
 
 # Validate that the version number has been updated.
 if ($currentProjectVersion -le $currentPublishedVersion) {

--- a/scripts/ValidateUpdatedNugetVersion.ps1
+++ b/scripts/ValidateUpdatedNugetVersion.ps1
@@ -45,7 +45,7 @@ if($xmlDoc.Project.PropertyGroup[0].VersionSuffix){
 $currentProjectVersion = [System.Management.Automation.SemanticVersion]"$versionPrefixString"
 
 Try {
-    $searchResultJson = dotnet package search $packageName --configfile $nugetConfigPath --exact-match --prerelease --format json
+    $searchResultJson = dotnet package search $packageName --configfile $nugetConfigPath --exact-match --prerelease --format json | Out-String
     if ($LASTEXITCODE -ne 0) {
         throw "dotnet package search exited with code $LASTEXITCODE"
     }

--- a/scripts/ValidateUpdatedNugetVersion.ps1
+++ b/scripts/ValidateUpdatedNugetVersion.ps1
@@ -16,6 +16,9 @@
 
 .Parameter projectPath
     Specifies the path to the project file.
+
+.Parameter nugetConfigPath
+    Specifies the path to the NuGet configuration for the Central Feed Service.
 #>
 
 Param(
@@ -23,7 +26,10 @@ Param(
     [string]$packageName,
 
     [parameter(Mandatory = $true)]
-    [string]$projectPath
+    [string]$projectPath,
+
+    [parameter(Mandatory = $true)]
+    [string]$nugetConfigPath
 )
 
 [xml]$xmlDoc = Get-Content $projectPath
@@ -38,25 +44,26 @@ if($xmlDoc.Project.PropertyGroup[0].VersionSuffix){
 # System.Version, get the version prefix.
 $currentProjectVersion = [System.Management.Automation.SemanticVersion]"$versionPrefixString"
 
-# API is case-sensitive
-$packageName = $packageName.ToLower()
-$url = "https://azuresearch-usnc.nuget.org/query?q=packageid:$packageName&prerelease=true&semVerLevel=2.0.0"
-
-# Call the NuGet API for the package and get the current published version.
 Try {
-    $nugetIndex = Invoke-RestMethod -Uri $url -Method Get
+    $searchResultJson = dotnet package search $packageName --configfile $nugetConfigPath --exact-match --prerelease --format json
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet package search exited with code $LASTEXITCODE"
+    }
+
+    $searchResult = $searchResultJson | ConvertFrom-Json
+    $matchingPackages = $searchResult.searchResult | ForEach-Object { $_.packages } | Where-Object { $_.id -ieq $packageName }
 }
 Catch {
-    if ($_.ErrorDetails.Message && $_.ErrorDetails.Message.Contains("The specified blob does not exist.")) {
-        Write-Host "No package exists. You will probably be publishing $packageName for the first time."
-        Exit # exit gracefully
-    }
-    
     Write-Host $_
     Exit 1
 }
 
-$currentPublishedVersion = [System.Management.Automation.SemanticVersion]$nugetIndex.data[0].version
+if (-not $matchingPackages) {
+    Write-Host "No package exists. You will probably be publishing $packageName for the first time."
+    Exit # exit gracefully
+}
+
+$currentPublishedVersion = ($matchingPackages | ForEach-Object { [System.Management.Automation.SemanticVersion]$_.version } | Sort-Object)[-1]
 
 # Validate that the version number has been updated.
 if ($currentProjectVersion -le $currentPublishedVersion) {


### PR DESCRIPTION
## Summary
- route the published-package version check through the authenticated Central Feed Service
- remove the direct public NuGet API request that triggers CFSClean
- pass the generated `nuget.config` into the validation script

## Validation
- exercised `dotnet package search --configfile` against Microsoft.Graph
- confirmed the version comparison still succeeds
 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/3162)