### PR TITLE
chore: add maxCpuCount:1 to avoids OOM kills (MSB4166)

### DIFF
--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
       - name: Build
-        run: dotnet build ${{ env.solutionName }} --no-restore -c Release /p:UseSharedCompilation=false -maxCpuCount:1
+        run: dotnet build ${{ env.solutionName }} --no-restore -c Release /p:UseSharedCompilation=false -m:1
       - name: Test
         run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover
       - name: Perform CodeQL Analysis

--- a/.github/workflows/validatePullRequest.yml
+++ b/.github/workflows/validatePullRequest.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore ${{ env.solutionName }}
       - name: Build
-        run: dotnet build ${{ env.solutionName }} --no-restore -c Release /p:UseSharedCompilation=false
+        run: dotnet build ${{ env.solutionName }} --no-restore -c Release /p:UseSharedCompilation=false -maxCpuCount:1
       - name: Test
         run: dotnet test ${{ env.solutionName }} --no-build --verbosity normal -c Release /p:CollectCoverage=true /p:CoverletOutput=TestResults/ /p:CoverletOutputFormat=opencover
       - name: Perform CodeQL Analysis


### PR DESCRIPTION
This PR adds -maxCpuCount:1 to avoid MSB4166 from the huge generated project building in parallel on the runner.

`-maxCpuCount:1` forces MSBuild to build projects sequentially in a single node, capping peak memory at the cost of some build time.

 ###### Microsoft Reviewers: [Open in CodeFlow](https://microsoft.github.io/open-pr/?codeflow=https://github.com/microsoftgraph/msgraph-sdk-dotnet/pull/3166)
